### PR TITLE
docs: Complete Kubernetes tutorial expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,53 @@
 # Formation/Notes Kubernetes
 
-Learning Kubernetes project
+Bienvenue dans cette formation Kubernetes ! Ce document sert de point d'entrée principal et de table des matières pour naviguer à travers les différents modules d'apprentissage.
+
+## Table des Matières
+
+1.  **Introduction à Kubernetes**
+    *   [Architecture de Kubernetes](./introduction/architecture.md)
+    *   [Contexte et Configuration (`kubectl`)](./introduction/context.md)
+
+2.  **Concepts et Objets Fondamentaux de Kubernetes**
+    *   [Pods](./objects/pods.md)
+    *   [Namespaces (Espaces de Noms)](./objects/namespace.md)
+    *   [Labels et Sélecteurs](./objects/labels-selectors.md)
+    *   [Annotations](./objects/annotations.md)
+    *   [Services](./objects/services.md)
+    *   [Deployments (Déploiements)](./objects/deployement.md)
+    *   [ReplicaSets](./objects/replicatSet.md)
+
+3.  **Gestion des Charges de Travail Avancées**
+    *   [StatefulSets](./objects/statefulsets.md)
+    *   [DaemonSets](./objects/daemonsets.md)
+    *   [Jobs (Tâches Batch)](./objects/jobs.md)
+    *   [CronJobs (Tâches Planifiées)](./objects/cronjobs.md)
+
+4.  **Gestion de la Configuration des Applications**
+    *   [ConfigMaps et Secrets](./objects/configApp.md)
+
+5.  **Réseautage dans Kubernetes**
+    *   [Ingress](./objects/ingress.md)
+    *   [NetworkPolicies (Politiques Réseau)](./objects/networkpolicies.md)
+
+6.  **Stockage dans Kubernetes**
+    *   [Vue d'ensemble du Stockage](./objects/storage-overview.md)
+    *   [PersistentVolumes (PV)](./objects/persistentvolumes.md)
+    *   [PersistentVolumeClaims (PVC)](./objects/persistentvolumeclaims.md)
+    *   [StorageClasses](./objects/storageclasses.md)
+
+7.  **Sécurité dans Kubernetes**
+    *   [Vue d'ensemble de la Sécurité](./security/security-overview.md)
+    *   [Role-Based Access Control (RBAC)](./security/rbac.md)
+    *   [Contextes de Sécurité (Security Contexts)](./security/security-contexts.md)
+
+8.  **Autres Ressources Utiles**
+    *   [Monitoring (Surveillance)](./divers/monitoring.md)
+    *   [Aide-Mémoire `kubectl` (Cheat Sheet)](./useful.md)
+
 ---
 
-```bash
+```python
 >>> import this
 The Zen of Python, by Tim Peters
 
@@ -30,5 +74,3 @@ Namespaces are one honking great idea -- let's do more of those!
 ```
 
 Enjoy!
-
-Next: [Architecture Kubernetes](/introduction/architecture.md)

--- a/introduction/context.md
+++ b/introduction/context.md
@@ -39,7 +39,6 @@ kubectl describe <resource-name> <obj-name>
 ```
 
 
-> Next: [Namespace](../objects/namespace.md)
+> Next: [Pods](../objects/pods.md)
 
 > [cheat sheet](../useful.md)
-

--- a/objects/persistentvolumeclaims.md
+++ b/objects/persistentvolumeclaims.md
@@ -1,0 +1,177 @@
+# PersistentVolumeClaims (PVC) Kubernetes
+
+Un PersistentVolumeClaim (PVC) est une demande de stockage faite par un utilisateur ou une application au sein d'un cluster Kubernetes. Il permet aux Pods d'accéder à des ressources de stockage persistantes (définies par des PersistentVolumes) sans avoir à connaître les détails de l'infrastructure de stockage sous-jacente.
+
+## Plongée dans les PersistentVolumeClaims (PVC)
+
+### Définition
+
+Un **PersistentVolumeClaim (PVC)** est un objet de l'API Kubernetes qui représente une requête pour un `PersistentVolume (PV)`. Les développeurs d'applications créent des PVCs pour "réclamer" une certaine quantité de stockage avec des caractéristiques spécifiques (comme la taille, le mode d'accès, et optionnellement une classe de stockage).
+
+*   **Demande de Stockage :** Un PVC est une demande de ressources de stockage (taille, modes d'accès).
+*   **Utilisation par les Pods :** Les Pods utilisent les PVCs comme des volumes. Le PVC abstrait les détails du PV sous-jacent.
+*   **Lien avec les PVs :** Kubernetes tente de satisfaire un PVC en le liant à un PV disponible qui correspond aux critères de la demande. Si le provisionnement dynamique est configuré (via une `StorageClass`), un nouveau PV peut être créé automatiquement pour satisfaire le PVC.
+
+### Analogie
+
+Si un [PersistentVolume (PV)](./persistentvolumes.md) est comme un "disque dur physique" disponible dans le datacenter (ou un volume de stockage cloud), alors un **PersistentVolumeClaim (PVC)** est comme un "bon de commande" ou une "requête" pour obtenir un disque dur avec des spécifications précises (par exemple, "j'ai besoin d'un disque de 10Go avec accès en lecture-écriture").
+
+### Portée au Namespace (Namespace-scoped)
+
+Contrairement aux PVs qui sont des ressources globales au cluster, les **PVCs doivent exister dans le même namespace que le Pod qui les utilise.** Un Pod dans le namespace `ns-app` ne peut utiliser qu'un PVC qui existe également dans `ns-app`.
+
+---
+
+## Champs Clés et Concepts d'un PVC
+
+Un manifeste de PersistentVolumeClaim contient plusieurs champs importants :
+
+### `accessModes`
+
+*   Définit les modes d'accès souhaités pour le volume. C'est une liste, et le PVC ne sera lié qu'à un PV qui supporte au moins l'un des modes demandés.
+*   Les modes sont les mêmes que pour les PVs :
+    *   **`ReadWriteOnce` (RWO) :** Le volume peut être monté en lecture-écriture par un seul nœud.
+    *   **`ReadOnlyMany` (ROX) :** Le volume peut être monté en lecture seule par plusieurs nœuds.
+    *   **`ReadWriteMany` (RWX) :** Le volume peut être monté en lecture-écriture par plusieurs nœuds.
+    *   **`ReadWriteOncePod` (RWOP) :** Le volume peut être monté en lecture-écriture par un seul Pod à la fois dans tout le cluster.
+*   Un PVC demande un ou plusieurs modes d'accès. Par exemple, `accessModes: ["ReadWriteOnce", "ReadOnlyMany"]` signifie que le PVC peut être satisfait par un PV offrant soit RWO, soit ROX (ou les deux). Cependant, une fois lié, un seul mode d'accès est choisi pour le montage (généralement le premier mode compatible trouvé).
+
+### `resources.requests.storage`
+
+*   Spécifie la quantité minimale de stockage requise.
+*   Exemple : `resources: { requests: { storage: 3Gi } }` (demande 3 Gibibytes).
+*   Le PVC ne sera lié qu'à un PV qui a au moins cette capacité. Kubernetes ne permet pas de lier un PVC de 10Gi à un PV de 5Gi.
+
+### `storageClassName`
+
+*   Le nom de la [StorageClass](./storageclasses.md) demandée pour ce PVC.
+*   **Comportement :**
+    *   **Si `storageClassName` est spécifié :**
+        *   Le PVC ne peut être lié qu'à un PV ayant la même `storageClassName`.
+        *   Si aucun PV statique correspondant n'est trouvé, la `StorageClass` nommée ici est utilisée pour tenter de provisionner dynamiquement un nouveau PV. Si la `StorageClass` n'existe pas ou ne peut pas provisionner, le PVC restera en attente (`Pending`).
+    *   **Si `storageClassName` est omis ou mis à `""` (chaîne vide) :**
+        *   **Provisionnement dynamique :** Si une `StorageClass` par défaut est configurée dans le cluster, Kubernetes peut l'utiliser pour provisionner dynamiquement un PV pour ce PVC. Le comportement exact (si une StorageClass par défaut est utilisée ou non lorsque `storageClassName` est omis) peut dépendre de la configuration du cluster (par exemple, des `Admission Controllers`).
+        *   **Liaison statique :** Le PVC ne peut être lié qu'à des PVs qui n'ont pas non plus de `storageClassName` (c'est-à-dire `storageClassName: ""`).
+*   Pour désactiver explicitement le provisionnement dynamique pour un PVC, vous pouvez le lier à une `StorageClass` qui n'a pas de provisionneur, ou mettre `storageClassName: ""` (et vous assurer qu'il n'y a pas de StorageClass par défaut ou qu'elle ne s'applique pas).
+
+### `volumeName` (Pour la Liaison Statique)
+
+*   Un PVC peut demander à être lié à un PV spécifique en fournissant le nom de ce PV dans le champ `spec.volumeName`.
+*   **Utilisation :** Cela contourne le processus de correspondance normal (basé sur la taille, les modes d'accès, et la `StorageClass`) et le provisionnement dynamique.
+*   **Conditions :** Le PV nommé doit exister, être `Available`, et satisfaire aux exigences du PVC (taille, modes d'accès).
+*   **Précaution :** L'utilisation de `volumeName` crée un couplage fort entre le PVC et un PV spécifique, ce qui rend la configuration moins portable et flexible. À utiliser avec discernement, principalement lorsque vous avez besoin de réutiliser un PV existant spécifique.
+
+### `selector` (Pour une Liaison Statique plus Affinée)
+
+*   Un PVC peut utiliser un `selector` pour affiner l'ensemble des PVs statiques auxquels il peut être lié. Le `selector` est une requête de labels.
+*   **Fonctionnement :** Seuls les PVs qui ont les labels correspondants au `selector` (et qui satisfont aussi aux autres exigences comme la taille et les modes d'accès) seront considérés pour la liaison.
+*   **Exemple :**
+    ```yaml
+    selector:
+      matchLabels:
+        environment: production
+        disktype: ssd
+    ```
+    Ce PVC ne se lierait qu'à des PVs ayant les labels `environment=production` ET `disktype=ssd`.
+*   C'est une alternative à `volumeName` pour une liaison statique plus flexible. Le `selector` n'est pas utilisé si le provisionnement dynamique est déclenché.
+
+### `status` (Phase)
+
+*   Indique l'état actuel du PVC. Ce champ est géré par Kubernetes.
+*   Phases possibles :
+    *   **`Pending` :** Le PVC a été créé mais n'est pas encore lié à un PV. Cela peut se produire si aucun PV correspondant n'est trouvé, si un PV correspondant est trouvé mais pas encore disponible, ou si le provisionnement dynamique est en cours.
+    *   **`Bound` :** Le PVC est lié avec succès à un PV. Le PVC peut maintenant être utilisé par un Pod.
+    *   **`Lost` :** Le PVC était lié à un PV, mais la liaison a été perdue (par exemple, si le PV a été supprimé manuellement ou est devenu inaccessible). Les données pourraient être perdues.
+
+---
+
+## Exemple de PVC
+
+Voici un exemple de manifeste pour un PersistentVolumeClaim :
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-app-pvc
+  namespace: my-app-namespace # Les PVCs sont à portée de namespace
+spec:
+  accessModes:
+    - ReadWriteOnce # Demande un accès en lecture-écriture par un seul nœud
+  resources:
+    requests:
+      storage: 2Gi # Demande 2 Gibibytes de stockage
+  # ----- Champs Optionnels -----
+  # storageClassName: "fast-ssd" 
+  # Si vous voulez utiliser une StorageClass spécifique pour le provisionnement dynamique
+  # ou pour lier à des PVs de cette classe.
+
+  # volumeName: "my-specific-pv"
+  # Pour lier ce PVC à un PV nommé "my-specific-pv".
+  # Utiliser cela désactive le provisionnement dynamique pour ce PVC.
+
+  # selector:
+  #   matchLabels:
+  #     environment: production
+  #     backup-policy: daily
+  # Pour filtrer les PVs statiques basés sur leurs labels.
+```
+
+---
+
+## Comment les Pods Utilisent les PVCs
+
+Les Pods accèdent au stockage persistant en montant un volume qui référence un PVC.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod-with-storage
+  namespace: my-app-namespace # Doit être le même namespace que le PVC
+spec:
+  containers:
+    - name: my-container
+      image: nginx
+      ports:
+        - containerPort: 80
+      volumeMounts: # Monte le volume dans le système de fichiers du conteneur
+        - name: my-storage-volume # Nom du volume défini ci-dessous
+          mountPath: /usr/share/nginx/html # Chemin de montage à l'intérieur du conteneur
+  volumes: # Définit les volumes disponibles pour ce Pod
+    - name: my-storage-volume # Nom arbitraire pour ce volume dans le contexte du Pod
+      persistentVolumeClaim:
+        claimName: my-app-pvc # Nom du PVC à utiliser (doit exister dans le même namespace)
+```
+
+**Explication :**
+1.  La section `spec.volumes` du Pod définit un volume nommé `my-storage-volume`.
+2.  Ce volume est de type `persistentVolumeClaim` et pointe vers le PVC nommé `my-app-pvc`.
+3.  La section `spec.containers[].volumeMounts` monte ensuite ce volume (`my-storage-volume`) à un chemin spécifique (`/usr/share/nginx/html`) à l'intérieur du conteneur.
+4.  L'application s'exécutant dans `my-container` peut alors lire et écrire des données dans `/usr/share/nginx/html`, et ces données seront stockées sur le PersistentVolume lié à `my-app-pvc`.
+
+---
+
+## Processus de Liaison (Binding)
+
+Lorsqu'un PVC est créé, Kubernetes lance un processus de contrôle pour trouver un PV approprié et le lier au PVC. Ce processus prend en compte plusieurs facteurs :
+
+1.  **`volumeName` :** Si `spec.volumeName` est spécifié dans le PVC, Kubernetes tente uniquement de lier ce PVC au PV portant ce nom. Si le PV n'existe pas ou ne correspond pas aux autres critères (taille, modes d'accès), le PVC reste `Pending`.
+2.  **`storageClassName` :**
+    *   Si une `storageClassName` est spécifiée dans le PVC :
+        *   **Liaison Statique :** Kubernetes recherche d'abord un PV `Available` ayant la même `storageClassName` et qui satisfait aux demandes de taille et de modes d'accès du PVC (et au `selector` du PVC, s'il est défini).
+        *   **Provisionnement Dynamique :** Si aucun PV statique approprié n'est trouvé et que la `StorageClass` spécifiée a un provisionneur configuré, le provisionneur est appelé pour créer un nouveau PV. Ce nouveau PV sera alors lié au PVC.
+    *   Si aucune `storageClassName` n'est spécifiée dans le PVC (ou si elle est `""`) :
+        *   **Liaison Statique :** Kubernetes recherche un PV `Available` qui n'a pas non plus de `storageClassName` et qui satisfait aux demandes de taille et de modes d'accès (et au `selector` du PVC, s'il est défini).
+        *   **Provisionnement Dynamique (via StorageClass par défaut) :** Si une `StorageClass` est marquée comme "default" dans le cluster, elle peut être utilisée pour le provisionnement dynamique même si le PVC ne la spécifie pas. Si aucune StorageClass par défaut n'existe ou si elle n'est pas configurée pour s'appliquer dans ce cas, et qu'aucun PV statique ne correspond, le PVC restera `Pending`.
+3.  **`accessModes` :** Le PV doit supporter au moins l'un des modes d'accès demandés par le PVC.
+4.  **`resources.requests.storage` :** La capacité du PV doit être supérieure ou égale à la capacité demandée par le PVC.
+5.  **`selector` :** Si un `selector` est défini dans le PVC, le PV doit avoir des labels qui correspondent à ce sélecteur (ceci s'applique principalement à la liaison statique).
+
+Une fois qu'un PV approprié est trouvé (ou provisionné), il est lié au PVC, et le statut des deux passe à `Bound`. Un PV ne peut être lié qu'à un seul PVC à la fois (relation un-à-un).
+
+---
+
+> Next: [StorageClasses](./storageclasses.md)
+
+> [cheat sheet](../useful.md)

--- a/objects/persistentvolumes.md
+++ b/objects/persistentvolumes.md
@@ -1,0 +1,143 @@
+# PersistentVolumes (PV) Kubernetes
+
+Un PersistentVolume (PV) est une abstraction de stockage dans Kubernetes qui représente une "pièce" de stockage physique ou réseau dans le cluster. Il est provisionné par un administrateur ou dynamiquement par une `StorageClass` et a un cycle de vie indépendant de tout Pod individuel.
+
+## Plongée dans les PersistentVolumes (PV)
+
+### Définition
+
+Un **PersistentVolume (PV)** est une ressource de l'API Kubernetes qui représente un volume de stockage existant, qu'il soit sur un système de stockage en réseau (comme NFS, iSCSI, Ceph), un service de stockage cloud (comme AWS EBS, Azure Disk, GCE Persistent Disk), ou même un répertoire local sur un nœud (pour le développement, via `hostPath`).
+
+*   **Ressource de Cluster :** Un PV est une ressource du cluster, tout comme un nœud. Il n'appartient pas à un namespace spécifique.
+*   **Gestion par l'Administrateur ou Dynamique :**
+    *   **Statique :** Un administrateur de cluster peut créer manuellement plusieurs PVs qui représentent le stockage disponible. Ces PVs sont alors disponibles pour être consommés par les utilisateurs via des PersistentVolumeClaims (PVCs).
+    *   **Dynamique :** Si aucun PV statique ne correspond à un PVC, le cluster peut essayer de provisionner dynamiquement un PV spécifiquement pour ce PVC, en utilisant une `StorageClass`.
+
+### Cycle de Vie
+
+Le cycle de vie d'un PV est distinct de celui d'un Pod. Les données stockées dans un PV persistent au-delà du redémarrage ou de la suppression des Pods qui l'utilisent. Un PV existe jusqu'à ce qu'il soit explicitement supprimé.
+
+### Analogie
+
+Pensez à un PV comme à un "disque dur physique" ou un "LUN (Logical Unit Number)" disponible dans le cluster. Bien qu'il puisse être virtuel ou défini par logiciel (comme un partage NFS ou un volume Ceph RBD), il représente une unité de stockage concrète que les applications peuvent utiliser.
+
+---
+
+## Champs Clés et Concepts d'un PV
+
+Un manifeste de PersistentVolume contient plusieurs champs importants :
+
+### `capacity`
+
+*   Définit la quantité totale de stockage du PV.
+*   Exemple : `capacity: { storage: 5Gi }` (5 Gibibytes), `capacity: { storage: 100Mi }` (100 Mebibytes).
+*   Un PV doit avoir une capacité spécifiée. Les PVCs demanderont une certaine capacité, et Kubernetes essaiera de faire correspondre cette demande à un PV disponible.
+
+### `volumeMode`
+
+*   Spécifie si le volume sera utilisé comme un système de fichiers ou un périphérique bloc brut.
+*   Valeurs possibles :
+    *   **`Filesystem` (par défaut) :** Le volume est monté dans les Pods comme un répertoire. Un système de fichiers est supposé exister (ou sera créé par Kubernetes pour certains types de volumes) sur le périphérique avant le montage.
+    *   **`Block` :** Le volume est présenté au Pod comme un périphérique bloc brut (par exemple, `/dev/xvda`). L'application dans le Pod est responsable de la gestion du périphérique bloc. Ce mode est utile pour les applications qui nécessitent un accès direct et de bas niveau au stockage, comme certaines bases de données.
+
+### `accessModes`
+
+*   Définit comment le volume peut être monté sur un nœud (et par conséquent, par les Pods sur ce nœud). C'est une liste de modes d'accès supportés par le PV.
+*   Modes d'accès courants :
+    *   **`ReadWriteOnce` (RWO) :** Le volume peut être monté en lecture-écriture par un **seul nœud** à la fois. Cela signifie que tous les Pods sur ce nœud spécifique peuvent lire et écrire sur le volume. C'est le mode le plus courant et il est supporté par la plupart des types de stockage.
+    *   **`ReadOnlyMany` (ROX) :** Le volume peut être monté en lecture seule par **plusieurs nœuds** simultanément.
+    *   **`ReadWriteMany` (RWX) :** Le volume peut être monté en lecture-écriture par **plusieurs nœuds** simultanément. Ce mode n'est supporté que par certains types de stockage partagé (par exemple, NFS, CephFS, GlusterFS, Azure Files). Les stockages bloc comme AWS EBS, GCE PD, Azure Disk ne supportent généralement pas RWX.
+    *   **`ReadWriteOncePod` (RWOP) :** (Stable/GA depuis Kubernetes 1.29) Le volume peut être monté en lecture-écriture par **un seul Pod** à la fois dans tout le cluster. C'est une contrainte plus forte que RWO, utile pour certaines applications sensibles.
+*   **Important :** Un PV peut spécifier plusieurs modes d'accès qu'il supporte. Un PVC demandera un mode d'accès spécifique, qui doit être l'un de ceux supportés par le PV pour qu'il y ait une liaison. Le fournisseur de stockage sous-jacent détermine quels modes d'accès sont réellement possibles.
+
+### `storageClassName`
+
+*   Un PV peut appartenir à une "classe" de stockage en spécifiant le nom d'une [StorageClass](./storageclasses.md) dans ce champ.
+*   **Liaison avec les PVCs :**
+    *   Un PV avec une `storageClassName` spécifique ne peut être lié qu'à des PVCs qui demandent explicitement cette même classe.
+    *   Un PV sans `storageClassName` (c'est-à-dire `storageClassName: ""`) ne peut être lié qu'à des PVCs qui ne spécifient pas de `storageClassName`.
+*   Ce champ est crucial pour le provisionnement dynamique, où la StorageClass définit comment créer de nouveaux PVs. Pour les PVs créés manuellement, il aide à les catégoriser.
+
+### `persistentVolumeReclaimPolicy`
+
+*   Définit ce qui arrive au PV (et à son volume de stockage sous-jacent) lorsque le PersistentVolumeClaim (PVC) auquel il était lié est supprimé.
+*   Valeurs possibles :
+    *   **`Retain` :** (Par défaut pour les PVs créés manuellement) Le PV reste dans le cluster après la suppression du PVC. Les données sur le volume sont préservées. L'administrateur du cluster doit manuellement nettoyer les données et supprimer le PV pour le rendre à nouveau disponible (ou le supprimer complètement). Le statut du PV passe à `Released`.
+    *   **`Delete` :** Le volume de stockage sous-jacent (par exemple, le disque EBS sur AWS, le disque persistant sur GCE) est supprimé lorsque le PVC est supprimé. C'est généralement la politique par défaut pour les PVs provisionnés dynamiquement par une StorageClass.
+    *   **`Recycle` (Obsolète) :** Effectue un nettoyage basique sur le volume (par exemple, `rm -rf /thevolume/*`) pour le rendre disponible pour un nouveau PVC. Cette politique est obsolète. Il est recommandé d'utiliser `Delete` et le provisionnement dynamique à la place. La plupart des provisionneurs de stockage ne supportent plus `Recycle`.
+
+### `status` (Phase)
+
+*   Indique l'état actuel du PV. Ce champ est géré par Kubernetes.
+*   Phases possibles :
+    *   **`Available` :** Le PV est libre et n'est pas encore lié à un PVC.
+    *   **`Bound` :** Le PV est lié à un PVC.
+    *   **`Released` :** Le PVC auquel le PV était lié a été supprimé, mais le PV n'a pas encore été récupéré par le cluster (par exemple, si la politique de récupération est `Retain`).
+    *   **`Failed` :** Le PV a rencontré une erreur (par exemple, lors du provisionnement ou de la suppression).
+
+---
+
+## Exemple de PV Créé Manuellement (type NFS)
+
+Voici un exemple de manifeste pour un PersistentVolume qui utilise un partage NFS existant.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: my-nfs-pv-example
+  labels: # Optionnel: pour l'organisation et la sélection
+    storage-type: network-attached-storage
+    environment: production
+spec:
+  capacity:
+    storage: 5Gi # Taille du volume
+  volumeMode: Filesystem # Mode du volume (système de fichiers)
+  accessModes:
+    - ReadWriteMany # NFS supporte généralement RWX, permettant à plusieurs nœuds de lire/écrire
+  persistentVolumeReclaimPolicy: Retain # Conserver le PV et les données après la suppression du PVC
+  storageClassName: "slow-nfs" # Associe ce PV à la StorageClass nommée "slow-nfs"
+                               # Si omis, ce PV ne peut être lié qu'à des PVCs sans storageClassName.
+  mountOptions: # Options de montage spécifiques au type de volume
+    - hard # Option de montage NFS "hard"
+    - nfsvers=4.1 # Utiliser la version 4.1 de NFS
+  nfs: # Section spécifique pour le type de volume NFS
+    path: /exports/data/prod # Chemin du répertoire exporté sur le serveur NFS
+    server: nfs-server.example.com # Adresse IP ou nom d'hôte du serveur NFS
+    readOnly: false # Indique si le montage doit être en lecture seule (ici, non)
+```
+
+**Explication des Champs Spécifiques :**
+
+*   **`spec.nfs` :** Cette section contient la configuration spécifique pour un volume de type NFS.
+    *   `path` : Le chemin qui est exporté par le serveur NFS.
+    *   `server` : L'adresse IP ou le nom d'hôte du serveur NFS.
+    *   `readOnly` : Si `true`, le montage sera en lecture seule.
+*   **`spec.mountOptions` :** Permet de spécifier des options de montage pour le volume, qui sont passées à l'outil de montage sous-jacent.
+*   **Autres Types de Volumes :** Kubernetes supporte de nombreux autres types de volumes pour les PVs, chacun avec sa propre section de configuration. Quelques exemples :
+    *   `awsElasticBlockStore` : Pour les volumes EBS d'Amazon Web Services.
+    *   `azureDisk` : Pour les disques managés Microsoft Azure.
+    *   `gcePersistentDisk` : Pour les disques persistants Google Compute Engine.
+    *   `iscsi` : Pour les volumes iSCSI.
+    *   `cephfs` : Pour les systèmes de fichiers CephFS.
+    *   `hostPath` : (Principalement pour le développement et les tests mono-nœud) Monte un fichier ou un répertoire du système de fichiers du nœud hôte.
+
+---
+
+## Interaction avec les PVCs et les StorageClasses
+
+*   **PVs comme "Offre" :** Les PersistentVolumes constituent l' "offre" de stockage disponible dans le cluster. Ils décrivent des ressources de stockage concrètes avec leurs capacités et caractéristiques.
+*   **PVCs comme "Demande" :** Les [PersistentVolumeClaims (PVCs)](./persistentvolumeclaims.md) sont la "demande" de stockage faite par les utilisateurs ou les applications. Un PVC demande une certaine quantité de stockage, des modes d'accès spécifiques, et peut optionnellement demander une `StorageClass`.
+*   **Liaison (Binding) :** Kubernetes tente de faire correspondre un PVC à un PV approprié. Pour qu'une liaison se produise :
+    *   Le PV doit avoir une capacité suffisante pour satisfaire la demande du PVC.
+    *   Les modes d'accès demandés par le PVC doivent être un sous-ensemble des modes d'accès offerts par le PV.
+    *   La `storageClassName` doit correspondre (si spécifiée dans le PVC et/ou le PV). Si le PVC spécifie une `storageClassName`, il ne peut être lié qu'à un PV de cette classe. Si le PVC ne spécifie pas de `storageClassName`, il ne peut être lié qu'à un PV qui n'a pas non plus de `storageClassName`.
+*   **Provisionnement Statique vs. Dynamique :**
+    *   **Statique :** Un administrateur crée manuellement des PVs (comme l'exemple NFS ci-dessus). Ces PVs sont ensuite disponibles pour être réclamés par des PVCs.
+    *   **Dynamique :** Si un PVC demande une `StorageClass` et qu'aucun PV statique ne correspond, la `StorageClass` peut automatiquement provisionner un nouveau PV pour répondre à la demande du PVC. Cette page se concentre sur l'objet PV lui-même, qui peut être le résultat de l'un ou l'autre de ces processus. Le provisionnement dynamique via les [StorageClasses](./storageclasses.md) sera détaillé dans une section ultérieure.
+
+---
+
+> Next: [PersistentVolumeClaims (PVC)](./persistentvolumeclaims.md)
+
+> [cheat sheet](../useful.md)

--- a/objects/pods.md
+++ b/objects/pods.md
@@ -55,6 +55,6 @@ kubectl apply -f pod.yaml
 kubectl describe pod pod-demo
 ```
 
-> Next: [ReplicatSets](../objects/replicatSet.md)
+> Next: [Namespace](./namespace.md)
 
 > [cheat sheet](../useful.md)

--- a/objects/storage-overview.md
+++ b/objects/storage-overview.md
@@ -1,0 +1,146 @@
+# Introduction au Stockage dans Kubernetes
+
+Le stockage est un aspect fondamental de la plupart des applications, en particulier pour les applications avec état (stateful) qui nécessitent de conserver des données au-delà du cycle de vie d'un Pod. Kubernetes offre un ensemble puissant de primitives pour gérer le stockage de manière flexible et découplée de l'exécution des conteneurs.
+
+## Pourquoi le Stockage est-il Crucial ?
+
+Dans un environnement conteneurisé comme Kubernetes, les conteneurs eux-mêmes sont souvent éphémères. Si un conteneur redémarre ou si un Pod est replanifié sur un autre nœud, toutes les données écrites directement dans le système de fichiers du conteneur sont perdues (sauf si un mécanisme de stockage externe est utilisé).
+
+Pour les applications qui ont besoin de :
+*   Conserver des données de manière persistante (bases de données, fichiers utilisateurs, etc.).
+*   Partager des fichiers entre plusieurs conteneurs au sein d'un même Pod.
+*   Accéder à des configurations ou des secrets montés en tant que fichiers.
+
+Kubernetes fournit plusieurs abstractions pour résoudre ces défis. Les concepts clés que nous allons explorer sont les **Volumes**, les **PersistentVolumes (PV)**, les **PersistentVolumeClaims (PVC)**, et les **StorageClasses**.
+
+---
+
+## Volumes
+
+Un **Volume** dans Kubernetes est essentiellement un répertoire, potentiellement avec des données, qui est accessible aux conteneurs d'un Pod.
+
+*   **Cycle de Vie :** La durée de vie d'un Volume est liée à celle du Pod qui l'encapsule. Un Volume survit aux redémarrages des conteneurs au sein du Pod. Ainsi, les données stockées dans un Volume sont préservées tant que le Pod existe. Lorsque le Pod est supprimé, le Volume est également détruit (sauf pour certains types de volumes persistants).
+*   **Partage :** Les Volumes peuvent être partagés entre les conteneurs d'un même Pod.
+
+### Types de Volumes Courants
+
+Kubernetes supporte de nombreux types de volumes. Voici quelques-uns des plus courants :
+
+*   **`emptyDir` :**
+    *   Crée un répertoire vide lorsque le Pod est assigné à un nœud.
+    *   Le répertoire existe tant que le Pod s'exécute sur ce nœud.
+    *   Si le Pod est supprimé, les données dans `emptyDir` sont définitivement perdues.
+    *   Utile pour l'espace de travail temporaire, le partage de fichiers entre conteneurs d'un même Pod.
+*   **`hostPath` :**
+    *   Monte un fichier ou un répertoire du système de fichiers du nœud hôte directement dans le Pod.
+    *   **Attention :** À utiliser avec une extrême prudence. Cela crée un couplage fort entre le Pod et le nœud, peut présenter des risques de sécurité, et n'est pas portable si le chemin n'existe pas sur tous les nœuds ou a un contenu différent.
+    *   Cas d'usage : Agents de nœud (comme des collecteurs de logs) qui ont besoin d'accéder à des parties spécifiques du système de fichiers du nœud.
+*   **`configMap` et `secret` :**
+    *   Permettent d'exposer des données de [ConfigMaps](./configApp.md#configmaps) ou des [Secrets](./configApp.md#secrets) en tant que fichiers dans un Pod.
+    *   Les fichiers sont en lecture seule par défaut.
+    *   Utile pour injecter des fichiers de configuration, des certificats, ou des clés API.
+*   **`persistentVolumeClaim` :**
+    *   Permet à un Pod d'utiliser un **PersistentVolume** (PV), qui est une ressource de stockage persistante gérée par le cluster. C'est la méthode privilégiée pour le stockage durable des données applicatives. Nous allons détailler ce concept ci-dessous.
+
+D'autres types de volumes existent pour des intégrations spécifiques avec des fournisseurs de stockage cloud (par exemple, `awsElasticBlockStore`, `azureDisk`, `gcePersistentDisk`) ou des systèmes de stockage réseau (par exemple, `nfs`, `cephfs`, `iscsi`).
+
+---
+
+## Concepts de Stockage Persistant (Aperçu)
+
+Pour les données qui doivent survivre au cycle de vie d'un Pod, Kubernetes introduit trois concepts principaux :
+
+### 1. PersistentVolume (PV)
+
+*   Un **PersistentVolume (PV)** est un morceau de stockage dans le cluster qui a été provisionné par un administrateur ou dynamiquement provisionné à l'aide d'une `StorageClass`.
+*   C'est une ressource du cluster, tout comme un nœud est une ressource du cluster. Les PVs sont des plugins de volume comme les Volumes, mais ont un cycle de vie indépendant de tout Pod individuel qui utilise le PV.
+*   Un PV capture les détails de l'implémentation du stockage, que ce soit NFS, iSCSI, ou un stockage spécifique à un fournisseur de cloud.
+
+### 2. PersistentVolumeClaim (PVC)
+
+*   Un **PersistentVolumeClaim (PVC)** est une demande de stockage faite par un utilisateur (ou une application via sa définition de Pod).
+*   Il est similaire à un Pod : les Pods consomment des ressources de nœud (CPU, mémoire) et les PVCs consomment des ressources de PV (stockage).
+*   Les PVCs peuvent demander une taille spécifique et des modes d'accès (par exemple, `ReadWriteOnce`, `ReadOnlyMany`, `ReadWriteMany`).
+    *   `ReadWriteOnce` (RWO) : Le volume peut être monté en lecture-écriture par un seul nœud.
+    *   `ReadOnlyMany` (ROX) : Le volume peut être monté en lecture seule par plusieurs nœuds.
+    *   `ReadWriteMany` (RWX) : Le volume peut être monté en lecture-écriture par plusieurs nœuds. (Supporté par certains types de stockage comme NFS).
+*   Lorsqu'un PVC est créé, Kubernetes tente de trouver un PV disponible qui satisfait aux exigences du PVC (taille, modes d'accès, StorageClass). Si un PV correspondant est trouvé (ou peut être provisionné), le PVC est lié (bound) à ce PV. Le Pod peut alors utiliser ce PVC pour accéder au stockage.
+
+### 3. StorageClass
+
+*   Une **StorageClass** fournit un moyen pour les administrateurs de décrire les "classes" de stockage qu'ils offrent. Différentes classes peuvent correspondre à :
+    *   Des niveaux de qualité de service (QoS) (par exemple, stockage SSD rapide vs. disques durs lents).
+    *   Des politiques de sauvegarde.
+    *   Des fournisseurs de stockage spécifiques ou des types de stockage (par exemple, `aws-ebs-gp3`, `nfs-fast`).
+    *   Des politiques arbitraires déterminées par les administrateurs du cluster.
+*   **Provisionnement Dynamique :** Le rôle principal des StorageClasses est de permettre le **provisionnement dynamique** des PersistentVolumes. Lorsqu'un PersistentVolumeClaim spécifie une StorageClass, et qu'aucun PV statique ne correspond, la StorageClass peut instruire le fournisseur de stockage sous-jacent (par exemple, AWS EBS, GCE PD, Azure Disk, ou un provisionneur interne comme NFS) de créer automatiquement un nouveau PV qui correspond aux besoins du PVC.
+
+---
+
+## Diagramme Conceptuel du Flux de Stockage
+
+Voici comment ces composants interagissent :
+
+1.  **Administrateur/Infrastructure :**
+    *   (Optionnel, pour le provisionnement statique) L'administrateur crée des `PersistentVolumes (PV)` qui représentent le stockage disponible.
+    *   L'administrateur définit des `StorageClasses` pour décrire les types de stockage et permettre le provisionnement dynamique.
+
+2.  **Utilisateur/Développeur :**
+    *   L'utilisateur crée un `PersistentVolumeClaim (PVC)` pour demander du stockage avec des spécifications (taille, mode d'accès, optionnellement une StorageClass).
+
+3.  **Système Kubernetes :**
+    *   Si une `StorageClass` est spécifiée dans le PVC et permet le provisionnement dynamique :
+        `StorageClass --(provisionne dynamiquement)--> PersistentVolume (PV)`
+    *   Kubernetes lie le `PVC` à un `PV` approprié (soit un PV existant qui correspond, soit un PV dynamiquement provisionné).
+        `PVC --(se lie à)--> PV`
+
+4.  **Pod :**
+    *   Le Pod définit un `Volume` de type `persistentVolumeClaim` qui référence le `PVC`.
+        `Pod --(utilise via un Volume)--> PVC`
+
+**Flux simplifié :**
+```
+Pod (référence un PVC dans sa définition de Volume)
+  |
+  v
+PersistentVolumeClaim (PVC) (demande de stockage)
+  |
+  v (est lié à)
+PersistentVolume (PV) (représente une pièce de stockage réelle)
+  |
+  v
+Stockage Physique/Cloud (ex: disque EBS, partage NFS, etc.)
+```
+
+**Avec Provisionnement Dynamique :**
+```
+Pod (référence un PVC)
+  |
+  v
+PersistentVolumeClaim (PVC) (spécifie une StorageClass)
+  |
+  v (déclenche)
+StorageClass (définit comment provisionner) --(crée)--> PersistentVolume (PV)
+                                                            |
+                                                            v (est lié au PVC ci-dessus)
+                                                          Stockage Physique/Cloud
+```
+
+---
+
+## Objectif de cette Section
+
+Cette page a introduit les concepts de base du stockage dans Kubernetes. Les pages suivantes de ce tutoriel approfondiront :
+
+*   **[PersistentVolumes (PV)](./persistentvolumes.md) :** Comment ils sont définis et gérés.
+*   **[PersistentVolumeClaims (PVC)](./persistentvolumeclaims.md) :** Comment les utilisateurs demandent du stockage.
+*   **[StorageClasses](./storageclasses.md) :** Pour le provisionnement dynamique et la classification du stockage.
+*   **Utilisation des Volumes dans les Pods :** Exemples concrets de montage de PVCs.
+
+Ces sections fourniront des exemples pratiques pour vous aider à configurer et utiliser le stockage persistant pour vos applications Kubernetes.
+
+---
+
+> Next: [PersistentVolumes (PV)](./persistentvolumes.md)
+
+> [cheat sheet](../useful.md)

--- a/objects/storageclasses.md
+++ b/objects/storageclasses.md
@@ -1,0 +1,164 @@
+# StorageClasses Kubernetes
+
+Une StorageClass est un objet de l'API Kubernetes qui permet aux administrateurs de définir différentes "classes" de stockage qu'ils offrent. Elles sont un composant clé pour le provisionnement dynamique des PersistentVolumes (PVs).
+
+## Introduction aux StorageClasses
+
+### Définition
+
+Une **StorageClass** fournit un moyen pour les administrateurs de décrire les "classes" (ou types) de stockage qu'ils proposent dans un cluster Kubernetes. Chaque StorageClass représente une configuration de stockage spécifique. Différentes classes peuvent correspondre à :
+
+*   Des niveaux de qualité de service (QoS) (par exemple, stockage SSD rapide vs. disques durs standards).
+*   Des politiques de sauvegarde.
+*   Des fournisseurs de stockage spécifiques ou des types de stockage (par exemple, `aws-ebs-gp3`, `nfs-fast`, `ceph-rbd`).
+*   Des politiques arbitraires déterminées par les administrateurs du cluster (par exemple, `billing-code=department-x`).
+
+### Objectif Principal : Provisionnement Dynamique
+
+L'objectif principal des StorageClasses est de permettre le **provisionnement dynamique** des PersistentVolumes (PVs).
+
+*   **Sans Provisionnement Dynamique (Statique) :** Un administrateur de cluster doit créer manuellement des PVs. Ces PVs représentent le stockage existant disponible pour être utilisé par les [PersistentVolumeClaims (PVCs)](./persistentvolumeclaims.md). Si aucun PV statique ne correspond à un PVC, le PVC reste en attente (`Pending`).
+*   **Avec Provisionnement Dynamique :** Au lieu que les administrateurs créent des PVs à l'avance, une StorageClass peut être configurée pour utiliser un **provisionneur** (un plugin de volume) qui créera automatiquement un nouveau PV lorsqu'un PVC le demande. Le PVC doit spécifier le nom de la StorageClass à utiliser.
+
+Cela simplifie grandement la gestion du stockage, car les utilisateurs n'ont plus besoin d'attendre qu'un administrateur crée un PV pour eux. Ils demandent simplement du stockage via un PVC en référençant une StorageClass, et le stockage est provisionné à la volée.
+
+---
+
+## Champs Clés et Concepts d'une StorageClass
+
+Un manifeste de StorageClass contient plusieurs champs importants :
+
+### `provisioner` (Obligatoire)
+
+*   Détermine quel plugin de volume est utilisé pour provisionner les PVs. Ce champ est **obligatoire**.
+*   Chaque fournisseur de stockage (cloud ou sur site) a son propre provisionneur.
+*   **Exemples de Provisionneurs Courants :**
+    *   `kubernetes.io/aws-ebs` : Pour les volumes Amazon Web Services Elastic Block Store.
+    *   `kubernetes.io/gce-pd` : Pour les Google Compute Engine Persistent Disks.
+    *   `kubernetes.io/azure-disk` : Pour les Microsoft Azure Managed Disks.
+    *   `kubernetes.io/azure-file` : Pour les partages de fichiers Microsoft Azure.
+    *   `kubernetes.io/cinder-block-storage` (ou anciennement `kubernetes.io/cinder`) : Pour OpenStack Cinder.
+    *   `kubernetes.io/vsphere-volume` : Pour VMware vSphere.
+    *   Provisionneurs pour des systèmes de stockage sur site comme Ceph RBD, GlusterFS, Portworx, etc. (par exemple, `ceph.com/rbd`, `kubernetes.io/glusterfs`).
+    *   `your-company.com/nfs` : Pour un provisionneur NFS externe ou personnalisé.
+*   **Note sur NFS :** Kubernetes lui-même ne fournit **pas** de provisionneur NFS interne. Si vous souhaitez un provisionnement dynamique pour NFS, vous devez déployer un provisionneur NFS externe (par exemple, le [NFS subdir external provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)).
+
+### `parameters` (Optionnel)
+
+*   Contient des paramètres spécifiques au provisionneur défini dans le champ `provisioner`. Ces paramètres sont opaques pour Kubernetes et sont interprétés uniquement par le provisionneur.
+*   La nature de ces paramètres varie considérablement d'un provisionneur à l'autre.
+*   **Exemples de Paramètres :**
+    *   Pour `kubernetes.io/aws-ebs` :
+        *   `type`: Type de volume EBS (par exemple, `gp2`, `gp3`, `io1`, `st1`, `sc1`).
+        *   `fsType`: Type de système de fichiers à créer (par exemple, `ext4`, `xfs`). Par défaut, `ext4`.
+        *   `encrypted`: `"true"` ou `"false"` pour activer/désactiver le chiffrement EBS.
+        *   `iopsPerGB`: Pour les volumes `io1`/`io2`/`gp3`, le nombre d'IOPS par GiB.
+    *   Pour `kubernetes.io/gce-pd` :
+        *   `type`: Type de disque (par exemple, `pd-standard`, `pd-ssd`).
+        *   `replication-type`: Pour les disques régionaux (par exemple, `regional-pd`), mettez à `regional-pd`. Sinon, `none`.
+        *   `fsType`: `ext4` ou `xfs`.
+    *   Pour un provisionneur NFS externe, les paramètres pourraient inclure le serveur NFS, le chemin de base, etc., bien que ces informations soient souvent configurées dans le déploiement du provisionneur lui-même.
+
+### `reclaimPolicy` (Optionnel)
+
+*   Spécifie la politique de récupération (`persistentVolumeReclaimPolicy`) pour les PVs qui sont dynamiquement créés par cette StorageClass.
+*   Valeurs possibles :
+    *   **`Delete` :** Lorsque le PVC est supprimé, le PV dynamiquement provisionné et le volume de stockage sous-jacent (par exemple, le disque EBS, le disque GCE) sont également supprimés. C'est souvent la politique par défaut pour les StorageClasses.
+    *   **`Retain` :** Lorsque le PVC est supprimé, le PV dynamiquement provisionné n'est pas supprimé. Il passe à l'état `Released` et doit être manuellement récupéré par un administrateur (ce qui peut impliquer la suppression manuelle des données sur le volume sous-jacent, puis la suppression du PV).
+*   Si ce champ est omis dans la StorageClass, il est généralement par défaut à `Delete`.
+
+### `volumeBindingMode` (Optionnel)
+
+*   Contrôle quand la liaison du PVC au PV (et donc le provisionnement dynamique) doit se produire.
+*   Valeurs possibles :
+    *   **`Immediate` (par défaut) :** Le provisionnement dynamique et la liaison se produisent dès que le PVC est créé.
+    *   **`WaitForFirstConsumer` :** Le provisionnement dynamique et la liaison sont retardés jusqu'à ce qu'un Pod qui utilise ce PVC soit créé et planifié.
+        *   **Utilité :** Ce mode est essentiel pour le stockage sensible à la topologie (par exemple, s'assurer qu'un volume EBS est créé dans la même zone de disponibilité que le nœud où le Pod sera planifié). Il permet au planificateur Kubernetes de prendre en compte les contraintes du Pod (comme les sélecteurs de nœuds, les affinités/anti-affinités) avant de décider où et comment provisionner le volume.
+
+### `allowVolumeExpansion` (Optionnel)
+
+*   Si mis à `true`, les PVCs créés à partir de cette StorageClass peuvent être agrandis après leur création.
+*   **Conditions :**
+    *   Le provisionneur de volume sous-jacent doit supporter l'expansion de volume.
+    *   Le PV doit avoir été créé avec `allowVolumeExpansion: true` (ce qui est hérité de la StorageClass).
+*   Pour agrandir un PVC, vous modifiez le champ `spec.resources.requests.storage` du PVC avec la nouvelle taille souhaitée.
+
+### `mountOptions` (Optionnel)
+
+*   Spécifie une liste d'options de montage par défaut pour les PVs qui sont dynamiquement provisionnés par cette StorageClass.
+*   Ces options sont passées à l'outil de montage du système d'exploitation lorsque le volume est monté sur un nœud.
+*   Exemple : `mountOptions: ["debug", "hard", "nfsvers=4.1"]` (les options spécifiques dépendent du type de volume).
+
+---
+
+## Exemple de StorageClass
+
+Voici un exemple de manifeste pour une StorageClass qui utilise le provisionneur AWS EBS.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast-ssd-aws # Nom de la StorageClass, utilisé par les PVCs
+provisioner: kubernetes.io/aws-ebs # Indique que nous utilisons le provisionneur AWS EBS
+parameters: # Paramètres spécifiques au provisionneur AWS EBS
+  type: gp3        # Type de volume EBS : General Purpose SSD v3
+  fsType: ext4     # Créer un système de fichiers ext4 sur le volume
+  # encrypted: "true" # Optionnel: pour chiffrer le volume EBS
+  # iopsPerGB: "50"   # Optionnel: pour gp3, peut être utilisé pour provisionner des IOPS spécifiques
+reclaimPolicy: Delete # Lorsque le PVC est supprimé, le volume EBS sous-jacent est également supprimé
+allowVolumeExpansion: true # Permet d'augmenter la taille des volumes créés avec cette classe
+volumeBindingMode: Immediate # Provisionner et lier le volume dès que le PVC est créé
+# mountOptions: # Optionnel: options de montage pour les volumes
+#   - debug
+```
+
+---
+
+## StorageClass par Défaut
+
+Un cluster Kubernetes peut avoir une StorageClass marquée comme **par défaut**.
+
+*   **Comportement :** Si un PersistentVolumeClaim (PVC) est créé sans spécifier de `storageClassName`, la StorageClass par défaut du cluster sera automatiquement utilisée pour le provisionnement dynamique (si le provisionnement dynamique est possible et qu'aucun PV statique ne correspond).
+*   **Comment Marquer comme Défaut :** Pour désigner une StorageClass comme étant celle par défaut, vous devez ajouter l'annotation `storageclass.kubernetes.io/is-default-class: "true"` à sa définition `metadata`.
+    ```yaml
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: standard-gp2
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true" # Marque cette SC comme défaut
+    provisioner: kubernetes.io/aws-ebs
+    parameters:
+      type: gp2
+    reclaimPolicy: Delete
+    # ... autres champs
+    ```
+*   **Unicité :** Il ne devrait y avoir qu'une seule StorageClass marquée comme défaut dans un cluster. Si plusieurs StorageClasses sont marquées comme défaut, Kubernetes peut ne pas se comporter comme prévu lors du traitement des PVCs sans `storageClassName` spécifié. Les nouvelles versions de Kubernetes peuvent empêcher de marquer plusieurs classes comme défaut.
+
+---
+
+## Utilisation avec les PVCs
+
+Les PersistentVolumeClaims (PVCs) utilisent les StorageClasses de deux manières principales :
+
+1.  **Pour le Provisionnement Dynamique :**
+    *   Un PVC spécifie le nom d'une StorageClass dans son champ `spec.storageClassName`.
+    *   Si aucun [PersistentVolume (PV)](./persistentvolumes.md) préexistant ne correspond aux critères du PVC (taille, modes d'accès, et cette `storageClassName`), le provisionneur associé à la StorageClass est invoqué pour créer un nouveau PV.
+    *   Ce nouveau PV est alors automatiquement lié au PVC.
+
+2.  **Pour la Liaison à des PVs Statiques :**
+    *   Même si des PVs sont créés manuellement (statiquement), ils peuvent être associés à une `storageClassName`.
+    *   Un PVC peut alors spécifier cette `storageClassName` pour s'assurer qu'il ne se lie qu'à des PVs de cette classe particulière, en plus de satisfaire les autres exigences comme la taille et les modes d'accès.
+
+Si un PVC ne spécifie pas de `storageClassName`, il peut :
+*   Utiliser la StorageClass par défaut du cluster pour le provisionnement dynamique.
+*   Se lier à un PV statique qui n'a pas non plus de `storageClassName` spécifié.
+
+Les StorageClasses offrent donc une grande flexibilité pour gérer comment et quel type de stockage est fourni aux applications dans Kubernetes.
+
+---
+
+> Next: [Sécurité dans Kubernetes](../security/security-overview.md)
+
+> [cheat sheet](../useful.md)

--- a/security/rbac.md
+++ b/security/rbac.md
@@ -1,0 +1,249 @@
+# Role-Based Access Control (RBAC) dans Kubernetes
+
+Le RBAC (Role-Based Access Control) est un mécanisme de sécurité fondamental dans Kubernetes qui permet de contrôler finement qui peut accéder à quelles ressources de l'API Kubernetes et quelles actions peuvent être effectuées sur ces ressources.
+
+## Introduction au RBAC
+
+### Qu'est-ce que le RBAC ?
+
+Le RBAC est une méthode de régulation de l'accès aux ressources informatiques ou réseau basée sur les **rôles** des utilisateurs individuels au sein d'une organisation. Au lieu d'assigner des permissions directement aux utilisateurs, les permissions sont regroupées dans des rôles, et ces rôles sont ensuite assignés aux utilisateurs.
+
+Dans Kubernetes, le "qui" peut être un utilisateur humain, un groupe d'utilisateurs, ou un **ServiceAccount** (une identité pour les processus s'exécutant dans les Pods). Le "quoi" (les actions) sont les verbes HTTP (`get`, `post`, `put`, `delete`) qui sont mappés à des verbes d'autorisation comme `list`, `create`, `update`, `patch`, `delete`, `watch`, etc. Les "ressources" sont les objets de l'API Kubernetes (Pods, Deployments, Services, Secrets, Nodes, etc.).
+
+### Importance dans Kubernetes
+
+Le RBAC est crucial pour la sécurité de Kubernetes car il permet d'appliquer le **principe du moindre privilège**. Ce principe stipule que chaque utilisateur, application ou composant du système ne doit disposer que des permissions strictement nécessaires pour accomplir ses tâches, et rien de plus.
+
+Sans RBAC (ou avec des configurations RBAC trop permissives), un utilisateur ou une application compromis pourrait potentiellement prendre le contrôle de l'ensemble du cluster. Le RBAC permet de segmenter les permissions et de réduire considérablement la surface d'attaque.
+
+Le RBAC est activé par défaut sur la plupart des clusters Kubernetes modernes (généralement depuis la version 1.6+).
+
+---
+
+## Objets Clés du RBAC
+
+Le système RBAC de Kubernetes est basé sur quatre objets principaux : `Role`, `ClusterRole`, `RoleBinding`, et `ClusterRoleBinding`.
+
+### 1. Role (Rôle)
+
+*   Un **Role** est utilisé pour accorder des permissions sur des ressources **au sein d'un namespace spécifique**.
+*   Il contient un ensemble de `rules` (règles) qui définissent les actions (verbes) autorisées sur un ensemble de ressources.
+
+**Champs d'une Règle (`rules`) :**
+*   **`apiGroups` :** Le groupe d'API de la ressource.
+    *   `""` (chaîne vide) : Indique le groupe d'API principal (core), qui contient des ressources comme `pods`, `services`, `configmaps`, `secrets`.
+    *   `apps` : Pour les ressources comme `deployments`, `statefulsets`, `daemonsets`.
+    *   `batch` : Pour les ressources `jobs`, `cronjobs`.
+    *   `networking.k8s.io` : Pour `ingresses`, `networkpolicies`.
+    *   Et bien d'autres (par exemple, `storage.k8s.io` pour `storageclasses`, `rbac.authorization.k8s.io` pour les objets RBAC eux-mêmes).
+*   **`resources` :** La liste des types de ressources auxquels la règle s'applique (par exemple, `pods`, `deployments`, `services`). Vous pouvez aussi spécifier des sous-ressources comme `pods/log` ou `deployments/scale`.
+*   **`verbs` :** La liste des actions autorisées. Verbes courants :
+    *   `get` : Lire une ressource spécifique.
+    *   `list` : Lister toutes les ressources d'un type donné.
+    *   `watch` : Surveiller les changements sur les ressources.
+    *   `create` : Créer une nouvelle ressource.
+    *   `update` : Mettre à jour une ressource existante.
+    *   `patch` : Appliquer une modification partielle à une ressource.
+    *   `delete` : Supprimer une ressource.
+    *   `deletecollection` : Supprimer une collection de ressources.
+
+**Exemple de YAML pour un Role :**
+Ce Role `pod-reader` dans le namespace `my-namespace` permet de lire les Pods et leurs logs, et de lister les Deployments.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: my-namespace
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indique le groupe d'API principal (core)
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["list"]
+```
+
+### 2. ClusterRole
+
+*   Un **ClusterRole** est similaire à un Role, mais il accorde des permissions **à l'échelle du cluster entier**.
+*   Il est utilisé pour :
+    *   Accorder des permissions sur des **ressources cluster-scoped** (qui ne sont pas dans un namespace), comme les Nœuds (`nodes`), les PersistentVolumes (`persistentvolumes`), les Namespaces (`namespaces`), les ClusterRoles eux-mêmes, etc.
+    *   Accorder des permissions sur des **ressources namespacées, mais dans tous les namespaces** (par exemple, permettre à un administrateur de lister tous les Pods dans tous les namespaces).
+    *   Accorder des permissions sur des **endpoints non-ressource** (par exemple, `/healthz`, `/metrics`).
+
+**Exemple de YAML pour un ClusterRole :**
+Ce ClusterRole `secret-reader` permet de lire les Secrets dans n'importe quel namespace et de lister les Nœuds.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # Pas de champ 'namespace' pour un ClusterRole, car il est global
+  name: secret-reader 
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"] # Ressource cluster-scoped
+  verbs: ["get", "list"]
+```
+
+### 3. RoleBinding (Liaison de Rôle)
+
+*   Un **RoleBinding** accorde les permissions définies dans un `Role` à un ensemble de `subjects` (utilisateurs, groupes, ou ServiceAccounts) **au sein d'un namespace spécifique**.
+*   Il lie un `Role` à des `subjects` dans le même namespace que le RoleBinding.
+
+**Champs Clés :**
+*   **`subjects` :** Une liste d'entités auxquelles les permissions sont accordées. Chaque sujet peut être :
+    *   `kind: User` : Pour un utilisateur humain. `name` est le nom de l'utilisateur (sensible à la casse).
+    *   `kind: Group` : Pour un groupe d'utilisateurs. `name` est le nom du groupe.
+    *   `kind: ServiceAccount` : Pour un ServiceAccount. `name` est le nom du ServiceAccount, et `namespace` (optionnel ici, car le RoleBinding est déjà namespacé) est le namespace du ServiceAccount.
+    *   `apiGroup: rbac.authorization.k8s.io` est utilisé pour `User` et `Group`.
+*   **`roleRef` :** Référence le `Role` (ou un `ClusterRole`, bien que ce soit moins courant pour un RoleBinding) dont les permissions sont accordées.
+    *   `kind: Role` : Indique que `name` fait référence à un Role.
+    *   `name` : Le nom du Role (doit exister dans le même namespace que le RoleBinding).
+    *   `apiGroup: rbac.authorization.k8s.io` : Le groupe d'API pour les objets RBAC.
+
+**Exemple de YAML pour un RoleBinding :**
+Ce RoleBinding `read-pods-in-my-namespace` accorde les permissions du Role `pod-reader` (défini précédemment) à un utilisateur, un groupe, et un ServiceAccount dans `my-namespace`.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-pods-in-my-namespace
+  namespace: my-namespace # Le RoleBinding est dans ce namespace
+subjects: # À qui les permissions sont accordées
+- kind: User
+  name: "jane.doe@example.com" # Nom d'utilisateur (sensible à la casse)
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: "developers" # Nom du groupe
+  apiGroup: rbac.authorization.k8s.io
+- kind: ServiceAccount
+  name: "my-service-account" # Nom du ServiceAccount
+  namespace: "my-namespace" # Doit être dans le même namespace que le RoleBinding
+roleRef: # Quel rôle est accordé
+  kind: Role # Le type de rôle (Role ou ClusterRole)
+  name: pod-reader # Nom du Role dans 'my-namespace'
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### 4. ClusterRoleBinding (Liaison de Rôle de Cluster)
+
+*   Un **ClusterRoleBinding** accorde les permissions définies dans un `ClusterRole` (ou parfois un `Role`) à des `subjects` **à l'échelle du cluster entier**.
+*   Il est utilisé pour accorder des permissions sur des ressources cluster-scoped, ou sur des ressources namespacées dans tous les namespaces.
+
+**Exemple de YAML pour un ClusterRoleBinding :**
+Ce ClusterRoleBinding `read-secrets-global` accorde les permissions du ClusterRole `secret-reader` (défini précédemment) au groupe `auditors` pour l'ensemble du cluster.
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  # Pas de champ 'namespace' pour un ClusterRoleBinding
+  name: read-secrets-global
+subjects:
+- kind: Group
+  name: "auditors"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole # Peut être Role ou ClusterRole. Généralement ClusterRole pour un accès global.
+  name: secret-reader # Nom du ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+```
+**Note :** Vous pouvez utiliser un ClusterRoleBinding pour lier un `Role` à des sujets cluster-wide. Dans ce cas, le `Role` sera appliqué à chaque namespace individuellement pour ces sujets. Cependant, il est plus courant d'utiliser un ClusterRoleBinding avec un ClusterRole pour des permissions véritablement globales.
+
+---
+
+## Sujets (Subjects) : Utilisateurs, Groupes, ServiceAccounts
+
+Les permissions RBAC sont accordées à des "sujets" :
+
+*   **Utilisateurs (Users) :**
+    *   Représentent des personnes humaines qui interagissent avec le cluster (développeurs, administrateurs).
+    *   Kubernetes **ne gère pas** les comptes utilisateurs de manière native. Il n'y a pas d'objet API pour les utilisateurs.
+    *   L'identité de l'utilisateur est généralement fournie par un système d'authentification externe (certificats clients, tokens de porteur, OpenID Connect (OIDC), etc.). Le nom d'utilisateur est la chaîne de caractères que ce système externe fournit à l'API Server.
+*   **Groupes (Groups) :**
+    *   Une collection d'utilisateurs. Comme les utilisateurs, les groupes sont gérés en dehors de Kubernetes.
+    *   Le système d'authentification peut fournir des informations de groupe pour un utilisateur.
+    *   Exemples de groupes intégrés : `system:authenticated` (tous les utilisateurs authentifiés), `system:unauthenticated` (utilisateurs anonymes).
+*   **ServiceAccounts (Comptes de Service) :**
+    *   Sont des identités pour les **processus s'exécutant à l'intérieur des Pods** lorsqu'ils ont besoin d'accéder à l'API Kubernetes.
+    *   Ils sont gérés par Kubernetes et sont des objets API (vous pouvez les créer, les lister, etc.).
+    *   Chaque namespace a un ServiceAccount par défaut nommé `default`. Si un Pod ne spécifie pas de `serviceAccountName`, il utilise le ServiceAccount `default` de son namespace.
+    *   Les ServiceAccounts sont souvent utilisés pour accorder des permissions granulaires aux applications (par exemple, un Pod qui a besoin de lister d'autres Pods dans son namespace).
+
+**Création d'un ServiceAccount :**
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-app-sa
+  namespace: my-app-ns
+# Vous pouvez aussi ajouter des annotations ou des labels ici
+# imagePullSecrets: # Si ce SA a besoin de tirer des images depuis des registres privés
+# - name: my-registry-secret
+```
+Pour l'utiliser, un Pod dans le namespace `my-app-ns` spécifierait `spec.serviceAccountName: my-app-sa`.
+
+---
+
+## Commandes `kubectl` Courantes pour RBAC
+
+*   **Vérifier si une action est autorisée (`kubectl auth can-i`) :**
+    Permet de tester si un utilisateur ou un ServiceAccount a la permission d'effectuer une action.
+    ```bash
+    # En tant que vous-même (votre identité kubectl actuelle)
+    kubectl auth can-i list pods --namespace my-namespace
+    kubectl auth can-i create deployments --namespace my-namespace
+    kubectl auth can-i get nodes # Pour une ressource cluster-scoped
+
+    # En tant qu'un autre utilisateur
+    kubectl auth can-i list secrets --namespace dev --as jane.doe@example.com
+
+    # En tant qu'un ServiceAccount
+    kubectl auth can-i get configmaps --namespace prod --as system:serviceaccount:prod:my-sa
+    ```
+
+*   **Lister les objets RBAC :**
+    ```bash
+    kubectl get roles --namespace my-namespace
+    kubectl get rolebindings --namespace my-namespace
+
+    kubectl get clusterroles
+    kubectl get clusterrolebindings
+
+    # Pour voir tous les rôles/bindings dans tous les namespaces (si vous avez les droits)
+    kubectl get roles --all-namespaces
+    kubectl get rolebindings --all-namespaces
+    ```
+
+*   **Décrire un objet RBAC (voir ses détails, y compris les règles) :**
+    ```bash
+    kubectl describe role pod-reader --namespace my-namespace
+    kubectl describe clusterrole secret-reader
+
+    kubectl describe rolebinding read-pods-in-my-namespace --namespace my-namespace
+    kubectl describe clusterrolebinding read-secrets-global
+    ```
+
+---
+
+## Bonnes Pratiques pour RBAC
+
+*   **Principe du Moindre Privilège :** C'est la règle d'or. N'accordez que les permissions strictement nécessaires pour la tâche à accomplir. Évitez d'accorder des permissions larges comme `cluster-admin` à des utilisateurs ou des ServiceAccounts à moins que ce ne soit absolument indispensable.
+*   **Utiliser les Roles et RoleBindings pour les Permissions Namespacées :** Pour les permissions qui ne concernent qu'un seul namespace, préférez toujours `Role` et `RoleBinding`.
+*   **Utiliser les ClusterRoles et ClusterRoleBindings avec Parcimonie :** N'accordez des permissions à l'échelle du cluster que lorsque c'est réellement nécessaire (par exemple, pour des administrateurs de cluster, des contrôleurs qui opèrent sur tout le cluster).
+*   **Favoriser les ServiceAccounts pour les Applications :** Ne laissez pas les Pods utiliser le ServiceAccount `default` s'ils ont besoin d'interagir avec l'API Kubernetes. Créez des ServiceAccounts dédiés avec des permissions RBAC minimales. N'utilisez pas de comptes utilisateurs humains pour les applications.
+*   **Réviser Régulièrement les Politiques RBAC :** Les besoins changent. Auditez périodiquement vos configurations RBAC pour vous assurer qu'elles sont toujours appropriées et pour supprimer les permissions inutiles.
+*   **Être Spécifique dans les Règles :**
+    *   Évitez d'utiliser des wildcards (`*`) pour `apiGroups`, `resources`, ou `verbs` autant que possible. Soyez aussi spécifique que possible.
+    *   Au lieu de donner `get`, `list`, `watch`, `create`, `update`, `patch`, `delete` sur `*` ressources dans `*` apiGroups, ciblez précisément ce qui est nécessaire.
+*   **Noms de Rôles Descriptifs :** Utilisez des noms clairs pour vos Roles et ClusterRoles qui indiquent leur fonction (par exemple, `configmap-editor`, `log-viewer`, `deployment-manager`).
+*   **Utiliser des Groupes :** Lorsque c'est possible (si votre système d'authentification le supporte), gérez les permissions pour des groupes d'utilisateurs plutôt que pour des utilisateurs individuels. Cela simplifie l'administration.
+
+---
+
+> Next: [Security Contexts](./security-contexts.md)
+
+> [cheat sheet](../useful.md)

--- a/security/security-contexts.md
+++ b/security/security-contexts.md
@@ -1,0 +1,186 @@
+# Contextes de Sécurité (Security Contexts) Kubernetes
+
+Les contextes de sécurité sont des champs dans les spécifications des Pods et des conteneurs qui permettent de définir des paramètres de privilèges et de contrôle d'accès. Ils sont essentiels pour renforcer la sécurité des charges de travail en limitant ce que les Pods et leurs conteneurs peuvent faire.
+
+## Introduction aux Contextes de Sécurité
+
+### Que sont-ils ?
+
+Un **Security Context** (contexte de sécurité) définit les paramètres de privilège et de contrôle d'accès pour un Pod ou un Conteneur. Cela inclut, par exemple, l'identifiant utilisateur (UID) et de groupe (GID) avec lequel le processus s'exécute, les capacités Linux à accorder ou à retirer, et si le conteneur peut s'exécuter en mode privilégié.
+
+### Objectif
+
+L'objectif principal des contextes de sécurité est de renforcer la sécurité en appliquant le **principe du moindre privilège**. En configurant des contextes de sécurité restrictifs, vous pouvez réduire la surface d'attaque de vos applications et limiter l'impact potentiel d'une compromission d'un conteneur.
+
+Ils permettent de contrôler finement les aspects de sécurité qui ne sont pas gérés par d'autres mécanismes comme le RBAC (qui contrôle l'accès à l'API Kubernetes) ou les NetworkPolicies (qui contrôlent le trafic réseau).
+
+---
+
+## Niveaux des Contextes de Sécurité
+
+Les contextes de sécurité peuvent être spécifiés à deux niveaux :
+
+1.  **Au Niveau du Pod (`spec.securityContext`) :**
+    *   Ces paramètres s'appliquent à **tous les conteneurs** au sein du Pod.
+    *   Ils définissent des valeurs par défaut pour les conteneurs du Pod.
+    *   Exemples : `runAsUser`, `runAsGroup`, `fsGroup`, `runAsNonRoot`.
+
+2.  **Au Niveau du Conteneur (`spec.containers[].securityContext`) :**
+    *   Ces paramètres sont spécifiques à un **conteneur individuel** au sein d'un Pod.
+    *   Si un paramètre est défini à la fois au niveau du Pod et au niveau du conteneur, la valeur spécifiée au niveau du **conteneur prévaut** pour ce conteneur.
+    *   Exemples : `runAsUser`, `capabilities`, `privileged`, `readOnlyRootFilesystem`.
+
+Cette hiérarchie permet de définir des politiques de sécurité de base pour un Pod entier tout en permettant des ajustements fins pour des conteneurs spécifiques si nécessaire.
+
+---
+
+## Champs Clés du Contexte de Sécurité (Niveau Pod)
+
+Ces champs sont définis dans `spec.securityContext` d'un Pod.
+
+*   **`runAsUser: <UID>` / `runAsGroup: <GID>` :**
+    *   Spécifie l'UID (User ID) et/ou le GID (Group ID) avec lequel le processus principal (entrypoint) de **tous les conteneurs** du Pod doit s'exécuter.
+    *   Si non spécifié, l'UID/GID utilisé est celui défini dans l'image du conteneur (souvent root, UID 0).
+    *   Il est fortement recommandé de définir `runAsUser` avec un UID non nul pour éviter de s'exécuter en tant que root.
+*   **`runAsNonRoot: true` :**
+    *   Si mis à `true`, Kubelet validera avant de lancer un conteneur que l'image n'est pas configurée pour s'exécuter en tant que root (UID 0). Si l'image tente de s'exécuter en tant que root, le Pod échouera au démarrage.
+    *   Ce champ est une mesure de sécurité importante pour s'assurer que les conteneurs ne s'exécutent pas avec des privilèges root.
+*   **`fsGroup: <GID>` :**
+    *   Spécifie un GID supplémentaire (supplemental group ID) qui s'applique à tous les conteneurs du Pod.
+    *   Ce GID est propriétaire de tous les fichiers créés dans les volumes montés par le Pod (comme `emptyDir` ou les volumes persistants).
+    *   Utile pour permettre à plusieurs conteneurs (s'exécutant potentiellement avec des UIDs différents mais partageant ce GID) de lire et écrire sur des volumes partagés.
+*   **`fsGroupChangePolicy: "OnRootMismatch" | "Always"` :**
+    *   Définit quand et comment la propriété et les permissions du `fsGroup` sont appliquées aux volumes.
+    *   `Always` : Kubelet change toujours récursivement la propriété et les permissions du volume pour correspondre au `fsGroup` lors du montage. Cela peut être lent pour les grands volumes.
+    *   `OnRootMismatch` (par défaut) : Kubelet ne change la propriété et les permissions que si le répertoire racine du volume n'a pas déjà la bonne propriété et les bonnes permissions. Cela peut accélérer le montage des volumes.
+*   **Modules de Sécurité Linux (Avancé) :**
+    *   **`seLinuxOptions` :** Configure le contexte SELinux pour les conteneurs du Pod. Nécessite que SELinux soit activé sur les nœuds.
+    *   **`seccompProfile` :** Permet de restreindre les appels système (syscalls) qu'un conteneur peut effectuer.
+        *   `type: RuntimeDefault` : Applique le profil seccomp par défaut fourni par le runtime de conteneur (par exemple, Docker, containerd). C'est une bonne pratique de sécurité.
+        *   `type: Unconfined` : Aucun profil seccomp n'est appliqué (potentiellement dangereux).
+        *   `type: Localhost, localhostProfile: <nom-profil.json>` : Utilise un profil seccomp personnalisé stocké sur le nœud.
+    *   **`appArmorProfile` :** Configure les profils AppArmor pour les conteneurs du Pod. Nécessite qu'AppArmor soit activé et configuré sur les nœuds.
+
+---
+
+## Champs Clés du Contexte de Sécurité (Niveau Conteneur)
+
+Ces champs sont définis dans `spec.containers[].securityContext` d'un conteneur spécifique. Ils peuvent surcharger les paramètres définis au niveau du Pod pour ce conteneur.
+
+*   **`runAsUser: <UID>` / `runAsGroup: <GID>` / `runAsNonRoot: true` :**
+    *   Mêmes significations qu'au niveau du Pod, mais s'appliquent uniquement à ce conteneur spécifique. Ils surchargent les valeurs du `securityContext` du Pod.
+*   **`privileged: true | false` :**
+    *   Si `true`, le conteneur s'exécute en mode privilégié. Cela désactive la plupart des mécanismes de sécurité des conteneurs et donne au conteneur un accès presque complet à tous les périphériques et capacités du nœud hôte.
+    *   **À utiliser avec une extrême prudence et uniquement si absolument nécessaire.** C'est une configuration très dangereuse qui expose le nœud hôte à des risques importants. Généralement non recommandé.
+*   **`allowPrivilegeEscalation: true | false` :**
+    *   Contrôle si un processus à l'intérieur du conteneur peut obtenir plus de privilèges que son processus parent.
+    *   Il est fortement recommandé de le mettre à `false` pour empêcher les processus d'escalader leurs privilèges (par exemple, via des binaires SUID ou SGID). `false` n'empêche pas le mode `privileged: true`.
+*   **`readOnlyRootFilesystem: true | false` :**
+    *   Si `true`, le système de fichiers racine du conteneur est monté en lecture seule.
+    *   C'est une excellente pratique de sécurité car cela empêche l'application (ou un attaquant) de modifier les fichiers du système d'exploitation du conteneur, y compris les binaires et les configurations.
+    *   L'application doit être conçue pour écrire ses données temporaires ou persistantes uniquement sur des volumes désignés (par exemple, `emptyDir` ou `persistentVolumeClaim`) qui sont montés en lecture-écriture.
+*   **`capabilities` :**
+    *   Permet de gérer finement les capacités Linux. Les capacités Linux divisent les privilèges root traditionnels en unités plus petites et distinctes.
+    *   **`add: [<capability_name>]` :** Ajoute des capacités spécifiques.
+    *   **`drop: [<capability_name>]` :** Retire des capacités spécifiques.
+    *   Il est recommandé de retirer toutes les capacités (`drop: ["ALL"]`) puis d'ajouter uniquement celles qui sont strictement nécessaires.
+    *   Exemple :
+        ```yaml
+        capabilities:
+          drop:
+          - ALL # Retire toutes les capacités par défaut
+          add:
+          - NET_BIND_SERVICE # Permet au conteneur de lier des ports inférieurs à 1024
+                             # sans avoir besoin d'être root (si runAsUser est non-root).
+          # - SYS_TIME # Permet de modifier l'heure système (généralement non nécessaire)
+          # - MKNOD # Permet de créer des fichiers de périphériques (généralement non nécessaire)
+        ```
+*   **`seLinuxOptions` / `seccompProfile` / `appArmorProfile` :**
+    *   Mêmes significations qu'au niveau du Pod, mais permettent une configuration plus fine pour chaque conteneur individuel.
+
+---
+
+## Exemple de Pod avec Contextes de Sécurité
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-pod-example
+spec:
+  securityContext: # Contexte de Sécurité au niveau du Pod
+    runAsUser: 1000 # Tous les conteneurs s'exécuteront en tant qu'UID 1000 par défaut
+    runAsGroup: 3000 # Tous les conteneurs s'exécuteront en tant que GID 3000 par défaut
+    fsGroup: 2000    # Les volumes seront accessibles par le groupe GID 2000
+    runAsNonRoot: true # Valide que les conteneurs ne s'exécutent pas en tant que root
+    seccompProfile: # Applique le profil seccomp par défaut du runtime
+      type: RuntimeDefault
+  containers:
+  - name: my-secure-container
+    image: my-app-image:latest # Remplacez par votre image
+    # Ports, variables d'environnement, etc.
+    securityContext: # Contexte de Sécurité au niveau du Conteneur
+      # runAsUser: 1001 # Pourrait surcharger runAsUser du Pod pour CE conteneur spécifique
+      # runAsGroup: 3001 # Pourrait surcharger runAsGroup du Pod
+      allowPrivilegeEscalation: false # Empêche l'escalade de privilèges
+      readOnlyRootFilesystem: true    # Le système de fichiers racine est en lecture seule
+      capabilities:
+        drop:
+        - ALL # Retire toutes les capacités
+        # add: # Ajoutez uniquement les capacités strictement nécessaires
+        # - NET_BIND_SERVICE
+    volumeMounts: # Exemple de montage de volume pour les données temporaires ou persistantes
+    - name: app-data
+      mountPath: /app/data # L'application peut écrire ici si readOnlyRootFilesystem est true
+  volumes:
+  - name: app-data
+    emptyDir: {} # Ou un persistentVolumeClaim
+```
+
+---
+
+## Interaction avec les Pod Security Standards (PSS) / Pod Security Admission (PSA)
+
+Kubernetes a évolué dans la manière dont les politiques de sécurité des Pods sont appliquées à l'échelle du cluster :
+
+*   **PodSecurityPolicies (PSP) :** (Déprécié à partir de Kubernetes 1.21 et supprimé en 1.25) Était un contrôleur d'admission qui validait les spécifications des Pods par rapport à des politiques définies.
+*   **Pod Security Admission (PSA) :** C'est le remplaçant intégré de PSP. C'est un contrôleur d'admission qui applique les **Pod Security Standards** (PSS).
+    *   Les **Pod Security Standards** sont des ensembles de politiques prédéfinies :
+        *   `Privileged` : Non sécurisé, essentiellement sans restrictions.
+        *   `Baseline` : Minimalement restrictif, bloque les escalades de privilèges connues.
+        *   `Restricted` : Très restrictif, suit les meilleures pratiques de durcissement actuelles.
+    *   PSA peut être configuré au niveau du namespace pour `enforce` (appliquer), `audit` (journaliser les violations), ou `warn` (avertir des violations) un standard spécifique.
+    *   Les **Contextes de Sécurité** sont les mécanismes que vous utilisez dans la définition de vos Pods et conteneurs pour vous assurer qu'ils respectent les exigences du standard PSS appliqué à leur namespace. Par exemple, le standard "Restricted" exige généralement :
+        *   `runAsNonRoot: true`
+        *   `seccompProfile: { type: RuntimeDefault }` ou un profil plus strict.
+        *   `capabilities: { drop: ["ALL"] }`
+        *   `allowPrivilegeEscalation: false`
+
+Configurer correctement les `securityContext` de vos Pods et conteneurs est donc essentiel pour satisfaire aux exigences des Pod Security Standards et pour sécuriser vos charges de travail.
+
+---
+
+## Bonnes Pratiques
+
+*   **Exécuter en tant qu'Utilisateur Non-Root :**
+    *   Utilisez `securityContext.runAsNonRoot: true` au niveau du Pod.
+    *   Spécifiez `securityContext.runAsUser: <UID_non_nul>` (par exemple, `1000`) et `securityContext.runAsGroup: <GID_non_nul>` (par exemple, `1000`). Assurez-vous que votre image de conteneur est construite pour s'exécuter avec cet UID/GID ou qu'elle peut le faire.
+*   **Système de Fichiers Racine en Lecture Seule :**
+    *   Utilisez `securityContext.readOnlyRootFilesystem: true` pour chaque conteneur.
+    *   Montez des volumes (`emptyDir` ou `persistentVolumeClaim`) pour les chemins où l'application a besoin d'écrire.
+*   **Empêcher l'Escalade de Privilèges :**
+    *   Utilisez `securityContext.allowPrivilegeEscalation: false` pour chaque conteneur.
+*   **Gérer les Capacités Linux :**
+    *   Retirez toutes les capacités par défaut : `securityContext.capabilities: { drop: ["ALL"] }`.
+    *   Ajoutez ensuite uniquement les capacités minimales requises : `add: ["CAP_NEEDED_1", "CAP_NEEDED_2"]`.
+*   **Utiliser les Profils Seccomp :**
+    *   Appliquez le profil seccomp par défaut du runtime : `securityContext.seccompProfile: { type: RuntimeDefault }`.
+    *   Pour une sécurité renforcée, envisagez des profils seccomp personnalisés qui ne listent que les appels système autorisés.
+*   **Éviter le Mode Privilégié :** N'utilisez `securityContext.privileged: true` sous aucun prétexte, sauf si c'est une exigence absolue et que vous comprenez pleinement les risques (par exemple, pour certains pilotes de périphériques de bas niveau).
+*   **Appliquer au Niveau du Pod et Surcharger si Nécessaire :** Définissez des contextes de sécurité restrictifs au niveau du Pod (`spec.securityContext`) comme base, et ne les assouplissez au niveau du conteneur (`spec.containers[].securityContext`) que pour les conteneurs qui en ont un besoin justifié.
+
+---
+
+> Next: [Cheat Sheet](../useful.md)
+
+> [cheat sheet](../useful.md)

--- a/security/security-overview.md
+++ b/security/security-overview.md
@@ -1,0 +1,99 @@
+# Introduction à la Sécurité Kubernetes
+
+La sécurité est un aspect fondamental de tout déploiement Kubernetes. Elle vise à protéger les applications, les données qu'elles traitent, ainsi que le cluster Kubernetes lui-même contre les menaces, les accès non autorisés et les vulnérabilités.
+
+Kubernetes, de par sa nature distribuée et sa complexité, présente une surface d'attaque potentielle qui nécessite une approche de sécurité multi-couches. Cette approche est souvent décrite par le modèle des **"4 C" de la Sécurité Cloud Native** : Cloud (ou Infrastructure d'entreprise), Cluster, Conteneur, et Code.
+
+Ce tutoriel se concentrera principalement sur les aspects de sécurité liés au **Cluster** et au **Conteneur** qui peuvent être configurés et gérés au sein de Kubernetes.
+
+Au cours de cette section sur la sécurité, nous aborderons les sujets suivants :
+*   **RBAC (Role-Based Access Control) :** Contrôler qui peut faire quoi sur les ressources du cluster.
+*   **Security Contexts (Contextes de Sécurité) :** Définir les privilèges et les permissions des Pods et des conteneurs.
+*   **Pod Security Admission (ou anciennement PodSecurityPolicies) :** Appliquer des standards de sécurité au niveau du cluster pour les Pods.
+*   Nous rappellerons également l'importance de la gestion sécurisée des **Secrets**.
+
+---
+
+## Les 4 C de la Sécurité Cloud Native (Brève Mention)
+
+Comprendre le modèle des "4 C" aide à situer les différentes responsabilités en matière de sécurité :
+
+1.  **Cloud / Infrastructure (Cloud/Cluster Infrastructure) :**
+    *   Concerne la sécurité de l'infrastructure sous-jacente sur laquelle Kubernetes est déployé. Cela inclut la sécurité physique des datacenters, la sécurité des réseaux virtuels, la sécurisation des machines virtuelles (VMs) ou des serveurs bare-metal, et la protection du système d'exploitation hôte.
+    *   **Responsabilité :** Généralement celle du fournisseur de cloud (pour les services managés Kubernetes comme GKE, EKS, AKS) ou de l'équipe d'infrastructure (pour les clusters auto-hébergés).
+
+2.  **Cluster :**
+    *   Concerne la sécurité des composants du cluster Kubernetes lui-même et de sa configuration.
+    *   Cela inclut la sécurisation de l'API Server (accès, authentification, autorisation), la protection d'etcd (la base de données du cluster), la sécurisation des kubelets sur chaque nœud, la configuration des politiques réseau, et la gestion des identités et des accès (RBAC).
+    *   **Responsabilité :** Partagée entre l'administrateur du cluster et les utilisateurs qui déploient des configurations.
+
+3.  **Conteneur (Container) :**
+    *   Concerne la sécurité du moteur d'exécution des conteneurs (par exemple, Docker, containerd) et, de manière cruciale, la sécurité des images de conteneurs.
+    *   Cela inclut l'utilisation d'images de base sécurisées et minimales, l'analyse des images pour détecter les vulnérabilités (CVEs), la configuration des conteneurs pour qu'ils s'exécutent avec le moins de privilèges possible (par exemple, en tant qu'utilisateur non-root), et la sécurisation des registres d'images.
+    *   **Responsabilité :** Principalement celle des développeurs et des équipes DevOps qui construisent et déploient les images.
+
+4.  **Code :**
+    *   Concerne la sécurité de l'application elle-même qui s'exécute à l'intérieur des conteneurs.
+    *   Cela inclut les pratiques de codage sécurisé, la gestion des dépendances (analyse des vulnérabilités dans les bibliothèques tierces), la protection contre les attaques courantes (par exemple, injection SQL, XSS), et la gestion des secrets applicatifs.
+    *   **Responsabilité :** Principalement celle des développeurs d'applications.
+
+Chaque couche s'appuie sur la sécurité de la couche inférieure. Une vulnérabilité dans une couche inférieure peut compromettre les couches supérieures.
+
+---
+
+## Concepts Clés de la Sécurité Kubernetes
+
+Voici un aperçu des concepts de sécurité importants dans Kubernetes, qui seront détaillés dans les pages suivantes :
+
+*   **Authentification & Autorisation :**
+    *   **Authentification (Qui peut accéder ?) :** Détermine comment les utilisateurs, les administrateurs, et les composants du système (comme les Pods via les ServiceAccounts) prouvent leur identité à l'API Server de Kubernetes. Les méthodes incluent les certificats clients, les tokens (tokens de porteur, tokens de ServiceAccount, tokens OIDC), et les webhooks d'authentification.
+    *   **Autorisation (Que peuvent-ils faire ?) :** Une fois authentifié, l'autorisation détermine si une identité a le droit d'effectuer une action spécifique (par exemple, créer un Pod, lister les Secrets) sur une ressource donnée. Kubernetes utilise principalement le **Role-Based Access Control (RBAC)**, qui sera notre principal point de focalisation. D'autres modes comme ABAC (Attribute-Based Access Control) ou les webhooks d'autorisation existent mais sont moins courants pour la gestion quotidienne.
+
+*   **Pod Security Standards / Contextes de Sécurité (Security Contexts) :**
+    *   Les **Contextes de Sécurité** (`securityContext`) permettent de définir des paramètres de sécurité au niveau du Pod et/ou du conteneur. Ces paramètres contrôlent les privilèges d'exécution, tels que :
+        *   Exécuter en tant qu'utilisateur/groupe non-root (`runAsUser`, `runAsGroup`).
+        *   Empêcher l'escalade de privilèges (`allowPrivilegeEscalation: false`).
+        *   Utiliser un système de fichiers racine en lecture seule (`readOnlyRootFilesystem: true`).
+        *   Définir les capacités Linux (`capabilities: { drop: ["ALL"], add: [...] }`).
+    *   Les **Pod Security Standards** (qui remplacent les PodSecurityPolicies dépréciées) définissent différents niveaux de sécurité (`Privileged`, `Baseline`, `Restricted`) que les Pods doivent respecter pour être admis dans le cluster. Ils sont appliqués via le **Pod Security Admission controller**.
+
+*   **Sécurité Réseau (Network Security) :**
+    *   Comme nous l'avons vu dans la section réseau, les [NetworkPolicies](../objects/networkpolicies.md) sont cruciales pour contrôler le flux de trafic entre les Pods et avec d'autres points de terminaison réseau. Elles permettent de segmenter le réseau et d'appliquer le principe du moindre privilège au niveau du réseau.
+
+*   **Gestion des Secrets (Secret Management) :**
+    *   Bien que les [Secrets](../objects/configApp.md#secrets) aient été couverts dans la gestion de la configuration, leur aspect sécurité est primordial.
+    *   Il est crucial d'activer le **chiffrement au repos (encryption at rest)** pour les Secrets dans etcd.
+    *   L'accès aux Secrets doit être strictement contrôlé via RBAC.
+    *   Pour des besoins avancés, des outils externes comme HashiCorp Vault ou Sealed Secrets peuvent être intégrés pour une gestion plus robuste des secrets.
+
+*   **Sécurité des Images de Conteneurs (Image Security) :**
+    *   Utiliser des images de base minimales et provenant de sources fiables.
+    *   Analyser régulièrement les images pour détecter les vulnérabilités connues (CVEs) en utilisant des outils comme Trivy, Clair, ou des scanners intégrés aux registres d'images.
+    *   Signer les images pour garantir leur intégrité et leur provenance.
+
+*   **Contrôleurs d'Admission (Admission Controllers) :**
+    *   Les contrôleurs d'admission sont des plugins de l'API Server qui interceptent les requêtes après leur authentification et leur autorisation, mais avant que l'objet ne soit persisté dans etcd.
+    *   Ils peuvent valider (`ValidatingAdmissionWebhook`) ou modifier (`MutatingAdmissionWebhook`) les objets.
+    *   Plusieurs contrôleurs d'admission sont importants pour la sécurité, notamment :
+        *   `PodSecurity` (le nouveau Pod Security Admission controller).
+        *   `PodSecurityPolicy` (déprécié à partir de Kubernetes 1.21 et supprimé en 1.25).
+        *   `LimitRanger` (pour appliquer les limites de ressources).
+        *   `ResourceQuota` (pour gérer les quotas de ressources par namespace).
+
+---
+
+## Principe du Moindre Privilège
+
+Un fil conducteur à travers toutes les stratégies de sécurité Kubernetes est le **principe du moindre privilège**. Cela signifie que chaque composant, utilisateur, ou application ne doit avoir que les permissions strictement nécessaires pour accomplir sa tâche, et rien de plus.
+
+*   **Pour les utilisateurs et les ServiceAccounts :** Définissez des rôles RBAC avec des permissions granulaires.
+*   **Pour les Pods et les conteneurs :** Utilisez les `securityContext` pour limiter les capacités, exécuter en tant qu'utilisateur non-root, etc.
+*   **Pour le réseau :** Utilisez les `NetworkPolicies` pour n'autoriser que les flux de communication nécessaires.
+
+Appliquer ce principe réduit considérablement la surface d'attaque et l'impact potentiel d'une compromission.
+
+---
+
+> Next: [Role-Based Access Control (RBAC)](./rbac.md)
+
+> [cheat sheet](../useful.md)

--- a/useful.md
+++ b/useful.md
@@ -68,62 +68,517 @@ node-3      Ready         45d   v1.12.1
 ```
 
 ## Get more information about a node
+```bash
+kubectl describe nodes <nom-du-noeud>
+# Alias: kubectl describe no <nom-du-noeud>
+```
+*Affiche des informations détaillées sur le nœud.*
+
+---
+## Gestion des Ressources de Base et Organisation
+
+### Namespaces (Espaces de Noms)
+Les Namespaces permettent de partitionner les ressources du cluster.
 
 ```bash
-kubectl describe nodes node-1
+# Lister tous les namespaces
+kubectl get namespaces
+# Alias: kubectl get ns
+
+# Décrire un namespace spécifique
+kubectl describe namespace <nom-namespace>
+# Alias: kubectl describe ns <nom-namespace>
+
+# Créer un nouveau namespace
+kubectl create namespace <nom-namespace>
+# Alias: kubectl create ns <nom-namespace>
+
+# Supprimer un namespace (Attention: supprime toutes les ressources qu'il contient!)
+kubectl delete namespace <nom-namespace>
+# Alias: kubectl delete ns <nom-namespace>
+
+# Changer le contexte kubectl actuel pour utiliser un namespace par défaut
+kubectl config set-context $(kubectl config current-context) --namespace=<nom-namespace>
 ```
 
-Output
+### Labels et Sélecteurs
+Les Labels sont des paires clé-valeur attachées aux objets, utilisées par les Sélecteurs pour les filtrer.
 
 ```bash
-Name:     node-1
-Role:
-Labels:   beta.kubernetes.io/arch=arm     # running an ARM processor
-          beta.kubernetes.io/os=linux     # running the Linux OS
-          kubernetes.io/hostname=node-1
+# Afficher les pods avec leurs labels
+kubectl get pods --show-labels
 
-Conditions:
-  Type            Status      LastHeartbeatTime       Reason                      Message
-  ----            ------      -----------------       ------                      -------
-  OutOfDisk       False       Sun, 05 Feb 2017…       KubeletHasSufficientDisk    kubelet…
-  MemoryPressure  False       Sun, 05 Feb 2017…       KubeletHasSufficientMemory  kubelet…
-  DiskPressure    False       Sun, 05 Feb 2017…       KubeletHasNoDiskPressure    kubelet…
-  Ready           True        Sun, 05 Feb 2017…       KubeletReady                kubelet…
+# Lister les pods avec un label spécifique (égalité)
+kubectl get pods -l environment=production
+# Alias: kubectl get po -l environment=production
 
-Capacity:
-  alpha.kubernetes.io/nvidia-gpu: 0
-  cpu:                            4
-  memory:                         882636Ki
-  pods:                           110
-Allocatable:
-  alpha.kubernetes.io/nvidia-gpu: 0
-  cpu:                            4
-  memory:                         882636Ki
-  pods:                           110
+# Lister les pods avec plusieurs labels (ET logique)
+kubectl get pods -l 'app=nginx,environment=dev'
 
-System Info:
-  Machine ID:                     9122895d0d494e3f97dda1e8f969c85c
-  System UUID:                    A7DBF2CE-DB1E-E34A-969A-3355C36A2149
-  Boot ID:                        ba53d5ee-27d2-4b6a-8f19-e5f702993ec6
-  Kernel Version:                 4.15.0-1037-azure
-  OS Image:                       Ubuntu 16.04.5 LTS
-  Operating System:               linux
-  Architecture:                   amd64
-  Container Runtime Version:      docker://3.0.4
-  Kubelet Version:                v1.12.6
-  Kube-Proxy Version:             v1.12.6
-PodCIDR:                          10.244.1.0/24
+# Lister les pods avec un label dont la valeur est dans un ensemble (IN)
+kubectl get pods -l 'environment in (production, qa)'
 
-Non-terminated Pods: (3 in total)
-  Namespace     Name          CPU Requests    CPU Limits    Memory Requests     Memory Limits
-  ---------     ----          ------------    ----------    ---------------     -------------
-  kube-system   kube-dns...   260m (6%)       0 (0%)        140Mi (16%)         220Mi (25%)
-  kube-system   kube-fla...   0 (0%)          0 (0%)        0 (0%)              0 (0%)
-  kube-system   kube-pro...   0 (0%)          0 (0%)        0 (0%)              0 (0%)
-Allocated resources:
-  (Total limits may be over 100 percent, i.e., overcommitted.
-  CPU Requests  CPU Limits    Memory Requests Memory Limits
-  ------------  ----------    --------------- -------------
-  260m (6%)     0 (0%)        140Mi (16%)     220Mi (25%)
-No events.
+# Lister les pods qui ont un label spécifique (existence)
+kubectl get pods -l 'exists(tier)'
+# Lister les pods qui n'ont PAS un label spécifique
+kubectl get pods -l '!exists(deprecated-label)' # Note: la syntaxe peut varier selon le shell
+
+# Ajouter un label à un pod
+kubectl label pods <nom-pod> nouvelle-version=v1.2.3
+
+# Modifier un label existant sur un pod (nécessite --overwrite)
+kubectl label pods <nom-pod> environnement=staging --overwrite
+
+# Supprimer un label d'un pod (en ajoutant un tiret à la fin du nom du label)
+kubectl label pods <nom-pod> ancienne-version-
 ```
+
+### Annotations
+Les Annotations permettent d'attacher des métadonnées non identifiantes aux objets.
+
+```bash
+# Ajouter/Mettre à jour une annotation sur un pod
+kubectl annotate pod <nom-pod> description="Ceci est mon pod de test"
+# Si l'annotation existe, utiliser --overwrite pour la modifier
+kubectl annotate pod <nom-pod> description="Nouvelle description" --overwrite
+
+# Supprimer une annotation d'un pod (en ajoutant un tiret à la fin du nom de l'annotation)
+kubectl annotate pod <nom-pod> description-
+
+# Les annotations sont visibles avec describe ou en format YAML/JSON
+kubectl describe pod <nom-pod>
+kubectl get pod <nom-pod> -o yaml
+```
+
+---
+## Gestion des Pods et Déploiements (Workloads)
+
+### Pods
+Commandes de base pour interagir avec les Pods.
+```bash
+# Lister tous les pods dans le namespace actuel
+kubectl get pods
+# Alias: kubectl get po
+
+# Lister les pods dans tous les namespaces
+kubectl get pods --all-namespaces
+# Alias: kubectl get po -A
+
+# Obtenir les détails d'un pod (configuration, statut, événements)
+kubectl describe pod <nom-pod> -n <nom-namespace> # Remplacer <nom-namespace> si pas default
+# Alias: kubectl describe po <nom-pod> -n <nom-namespace>
+
+# Afficher les logs d'un pod
+kubectl logs <nom-pod> -n <nom-namespace>
+# Pour suivre les logs en temps réel:
+kubectl logs -f <nom-pod> -n <nom-namespace>
+# Pour voir les logs d'un conteneur spécifique dans un pod multi-conteneurs:
+kubectl logs <nom-pod> -c <nom-conteneur> -n <nom-namespace>
+# Pour voir les logs des pods précédents (si redémarrage)
+kubectl logs --previous <nom-pod> -n <nom-namespace>
+
+
+# Exécuter une commande dans un pod
+kubectl exec <nom-pod> -n <nom-namespace> -- <commande> <args...>
+# Exemple: kubectl exec my-pod -n default -- ls /app
+# Pour obtenir un shell interactif:
+kubectl exec -it <nom-pod> -n <nom-namespace> -- /bin/sh # ou /bin/bash
+
+# Copier des fichiers depuis/vers un pod
+kubectl cp <nom-pod>:<chemin-source-pod> <chemin-destination-local> -n <nom-namespace>
+kubectl cp <chemin-source-local> <nom-pod>:<chemin-destination-pod> -n <nom-namespace>
+
+# Supprimer un pod (sera souvent recréé par un Deployment, ReplicaSet, etc.)
+kubectl delete pod <nom-pod> -n <nom-namespace>
+```
+
+### Deployments
+Gèrent le déploiement et la mise à jour des applications sans état.
+```bash
+# Lister les deployments
+kubectl get deployments -n <nom-namespace>
+# Alias: kubectl get deploy -n <nom-namespace>
+
+# Décrire un deployment
+kubectl describe deployment <nom-deployment> -n <nom-namespace>
+# Alias: kubectl describe deploy <nom-deployment> -n <nom-namespace>
+
+# Mettre à l'échelle un deployment (changer le nombre de réplicas)
+kubectl scale deployment <nom-deployment> --replicas=5 -n <nom-namespace>
+
+# Voir l'état d'un déploiement (rolling update)
+kubectl rollout status deployment/<nom-deployment> -n <nom-namespace>
+
+# Voir l'historique des révisions d'un deployment
+kubectl rollout history deployment/<nom-deployment> -n <nom-namespace>
+
+# Revenir à une révision précédente
+kubectl rollout undo deployment/<nom-deployment> --to-revision=<numero-revision> -n <nom-namespace>
+
+# Redémarrer un déploiement (provoque une mise à jour progressive avec la même spec)
+kubectl rollout restart deployment/<nom-deployment> -n <nom-namespace>
+
+# Supprimer un deployment (supprime aussi les ReplicaSets et Pods associés)
+kubectl delete deployment <nom-deployment> -n <nom-namespace>
+```
+
+### StatefulSets
+Pour les applications avec état nécessitant des identités stables et un stockage persistant.
+```bash
+# Lister les StatefulSets
+kubectl get statefulsets -n <nom-namespace>
+# Alias: kubectl get sts -n <nom-namespace>
+
+# Décrire un StatefulSet
+kubectl describe statefulset <nom-sts> -n <nom-namespace>
+# Alias: kubectl describe sts <nom-sts> -n <nom-namespace>
+
+# Mettre à l'échelle un StatefulSet
+kubectl scale statefulset <nom-sts> --replicas=<nombre> -n <nom-namespace>
+
+# Voir l'état du déploiement d'un StatefulSet
+kubectl rollout status statefulset/<nom-sts> -n <nom-namespace>
+
+# Supprimer un StatefulSet (Attention: les PVCs peuvent ne pas être supprimés, selon la reclaimPolicy)
+kubectl delete statefulset <nom-sts> -n <nom-namespace>
+```
+
+### DaemonSets
+Assurent qu'une copie d'un Pod s'exécute sur tous les nœuds (ou un sous-ensemble).
+```bash
+# Lister les DaemonSets
+kubectl get daemonsets -n <nom-namespace>
+# Alias: kubectl get ds -n <nom-namespace>
+
+# Décrire un DaemonSet
+kubectl describe daemonset <nom-ds> -n <nom-namespace>
+# Alias: kubectl describe ds <nom-ds> -n <nom-namespace>
+
+# Voir l'état du déploiement d'un DaemonSet
+kubectl rollout status daemonset/<nom-ds> -n <nom-namespace>
+
+# Supprimer un DaemonSet
+kubectl delete daemonset <nom-ds> -n <nom-namespace>
+```
+
+### Jobs
+Pour exécuter des tâches batch qui se terminent.
+```bash
+# Lister les Jobs
+kubectl get jobs -n <nom-namespace>
+
+# Décrire un Job (utile pour voir les Pods créés et leur statut)
+kubectl describe job <nom-job> -n <nom-namespace>
+
+# Afficher les logs d'un Pod créé par un Job (le nom du Pod est souvent <nom-job>-<hash>)
+# D'abord, trouver le nom du Pod: kubectl get pods -l job-name=<nom-job> -n <nom-namespace>
+kubectl logs <nom-pod-du-job> -n <nom-namespace>
+
+# Attendre qu'un Job se termine
+kubectl wait --for=condition=complete job/<nom-job> -n <nom-namespace> --timeout=300s
+
+# Supprimer un Job (et les Pods qu'il a créés)
+kubectl delete job <nom-job> -n <nom-namespace>
+```
+
+### CronJobs
+Pour planifier l'exécution récurrente de Jobs.
+```bash
+# Lister les CronJobs
+kubectl get cronjobs -n <nom-namespace>
+# Alias: kubectl get cj -n <nom-namespace>
+
+# Décrire un CronJob (voir la planification, le template de Job, les Jobs récents)
+kubectl describe cronjob <nom-cj> -n <nom-namespace>
+# Alias: kubectl describe cj <nom-cj> -n <nom-namespace>
+
+# Surveiller les Jobs créés par les CronJobs (utile pour le débogage)
+kubectl get jobs --watch -n <nom-namespace>
+
+# Déclencher manuellement un Job à partir d'un template de CronJob
+kubectl create job <nom-job-manuel> --from=cronjob/<nom-cj> -n <nom-namespace>
+
+# Suspendre/Reprendre un CronJob
+kubectl patch cronjob <nom-cj> -p '{"spec": {"suspend": true}}' -n <nom-namespace>
+kubectl patch cronjob <nom-cj> -p '{"spec": {"suspend": false}}' -n <nom-namespace>
+
+# Supprimer un CronJob (ne supprime pas les Jobs actifs ou terminés qu'il a créés)
+kubectl delete cronjob <nom-cj> -n <nom-namespace>
+```
+
+---
+## Configuration des Applications
+
+### ConfigMaps
+Pour stocker des données de configuration non sensibles.
+```bash
+# Lister les ConfigMaps
+kubectl get configmaps -n <nom-namespace>
+# Alias: kubectl get cm -n <nom-namespace>
+
+# Décrire un ConfigMap
+kubectl describe configmap <nom-cm> -n <nom-namespace>
+# Alias: kubectl describe cm <nom-cm> -n <nom-namespace>
+
+# Créer un ConfigMap à partir de littéraux ou de fichiers
+kubectl create configmap <nom-cm> \
+  --from-literal=cle1=valeur1 \
+  --from-literal=cle2=valeur2 \
+  --from-file=chemin/vers/fichier.conf \
+  -n <nom-namespace>
+
+# Modifier un ConfigMap (par exemple, en l'ouvrant dans l'éditeur par défaut)
+kubectl edit configmap <nom-cm> -n <nom-namespace>
+
+# Supprimer un ConfigMap
+kubectl delete configmap <nom-cm> -n <nom-namespace>
+```
+
+### Secrets
+Pour stocker des données sensibles (mots de passe, tokens, clés).
+```bash
+# Lister les Secrets
+kubectl get secrets -n <nom-namespace>
+
+# Décrire un Secret (ne montre PAS les valeurs décodées)
+kubectl describe secret <nom-secret> -n <nom-namespace>
+
+# Créer un Secret générique à partir de littéraux ou de fichiers
+kubectl create secret generic <nom-secret> \
+  --from-literal=utilisateur=admin \
+  --from-literal=motdepasse='S!cr3t' \
+  --from-file=chemin/vers/cert.pem \
+  -n <nom-namespace>
+
+# Créer un Secret pour un registre Docker privé
+kubectl create secret docker-registry <nom-secret-registre> \
+  --docker-server=<serveur-registre> \
+  --docker-username=<utilisateur> \
+  --docker-password=<mot-de-passe> \
+  --docker-email=<email> \
+  -n <nom-namespace>
+
+# Afficher une valeur de Secret (décodée)
+# ATTENTION: Affiche des informations sensibles en clair dans votre terminal!
+echo $(kubectl get secret <nom-secret> -n <nom-namespace> -o jsonpath='{.data.<cle-du-secret>}' | base64 --decode)
+# Exemple: echo $(kubectl get secret my-db-secret -n default -o jsonpath='{.data.password}' | base64 --decode)
+
+# Supprimer un Secret
+kubectl delete secret <nom-secret> -n <nom-namespace>
+```
+
+---
+## Réseautage (Networking)
+
+### Services
+Exposent des applications s'exécutant sur un ensemble de Pods.
+```bash
+# Lister les services
+kubectl get services -n <nom-namespace>
+# Alias: kubectl get svc -n <nom-namespace>
+
+# Décrire un service
+kubectl describe service <nom-service> -n <nom-namespace>
+# Alias: kubectl describe svc <nom-service> -n <nom-namespace>
+
+# Exposer un Deployment avec un Service (type ClusterIP par défaut)
+kubectl expose deployment <nom-deployment> --port=<port-externe> --target-port=<port-conteneur> -n <nom-namespace>
+# Pour un type NodePort: kubectl expose deployment <nom-deployment> --type=NodePort --port=80 --target-port=8080
+
+# Supprimer un service
+kubectl delete service <nom-service> -n <nom-namespace>
+```
+
+### Ingress
+Gère l'accès externe aux services HTTP/HTTPS du cluster.
+```bash
+# Lister les Ingress
+kubectl get ingress -n <nom-namespace>
+# Alias: kubectl get ing -n <nom-namespace>
+
+# Décrire un Ingress
+kubectl describe ingress <nom-ingress> -n <nom-namespace>
+# Alias: kubectl describe ing <nom-ingress> -n <nom-namespace>
+
+# Supprimer un Ingress
+kubectl delete ingress <nom-ingress> -n <nom-namespace>
+```
+
+### NetworkPolicies (Politiques Réseau)
+Contrôlent le flux de trafic entre les Pods.
+```bash
+# Lister les NetworkPolicies
+kubectl get networkpolicies -n <nom-namespace>
+# Alias: kubectl get netpol -n <nom-namespace>
+
+# Décrire une NetworkPolicy
+kubectl describe networkpolicy <nom-netpol> -n <nom-namespace>
+# Alias: kubectl describe netpol <nom-netpol> -n <nom-namespace>
+
+# Supprimer une NetworkPolicy
+kubectl delete networkpolicy <nom-netpol> -n <nom-namespace>
+```
+
+---
+## Stockage (Storage)
+
+### PersistentVolumes (PVs)
+Représentent des morceaux de stockage dans le cluster.
+```bash
+# Lister les PersistentVolumes
+kubectl get persistentvolumes
+# Alias: kubectl get pv
+
+# Décrire un PersistentVolume
+kubectl describe persistentvolume <nom-pv>
+# Alias: kubectl describe pv <nom-pv>
+
+# Supprimer un PersistentVolume (si la politique de récupération le permet ou pour nettoyage manuel)
+kubectl delete persistentvolume <nom-pv>
+```
+
+### PersistentVolumeClaims (PVCs)
+Demandes de stockage par les utilisateurs/applications.
+```bash
+# Lister les PersistentVolumeClaims
+kubectl get persistentvolumeclaims -n <nom-namespace>
+# Alias: kubectl get pvc -n <nom-namespace>
+
+# Décrire un PersistentVolumeClaim
+kubectl describe persistentvolumeclaim <nom-pvc> -n <nom-namespace>
+# Alias: kubectl describe pvc <nom-pvc> -n <nom-namespace>
+
+# Supprimer un PersistentVolumeClaim (peut déclencher la politique de récupération du PV)
+kubectl delete persistentvolumeclaim <nom-pvc> -n <nom-namespace>
+```
+
+### StorageClasses
+Définissent les "classes" de stockage disponibles.
+```bash
+# Lister les StorageClasses
+kubectl get storageclasses
+# Alias: kubectl get sc
+
+# Décrire une StorageClass
+kubectl describe storageclass <nom-sc>
+# Alias: kubectl describe sc <nom-sc>
+
+# Marquer une StorageClass comme défaut (remplacer <nom-sc> par le nom de la classe)
+kubectl patch storageclass <nom-sc> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+# Retirer le statut par défaut d'une StorageClass
+kubectl patch storageclass <nom-sc> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
+
+---
+## Sécurité et Contrôle d'Accès (RBAC)
+
+### ServiceAccounts (Comptes de Service)
+Identités pour les processus s'exécutant dans les Pods.
+```bash
+# Lister les ServiceAccounts dans un namespace
+kubectl get serviceaccounts -n <nom-namespace>
+# Alias: kubectl get sa -n <nom-namespace>
+
+# Créer un ServiceAccount
+kubectl create serviceaccount <nom-sa> -n <nom-namespace>
+
+# Décrire un ServiceAccount
+kubectl describe serviceaccount <nom-sa> -n <nom-namespace>
+# Alias: kubectl describe sa <nom-sa> -n <nom-namespace>
+
+# Supprimer un ServiceAccount
+kubectl delete serviceaccount <nom-sa> -n <nom-namespace>
+```
+
+### RBAC (Roles, ClusterRoles, RoleBindings, ClusterRoleBindings)
+Gestion des permissions basées sur les rôles.
+```bash
+# Lister les Roles (namespacés)
+kubectl get roles -n <nom-namespace>
+# Lister tous les Roles dans tous les namespaces (si droits suffisants)
+kubectl get roles --all-namespaces
+
+# Lister les ClusterRoles (globaux au cluster)
+kubectl get clusterroles
+
+# Lister les RoleBindings (namespacés)
+kubectl get rolebindings -n <nom-namespace>
+# Lister tous les RoleBindings dans tous les namespaces
+kubectl get rolebindings --all-namespaces
+
+# Lister les ClusterRoleBindings (globaux au cluster)
+kubectl get clusterrolebindings
+
+# Décrire un Role
+kubectl describe role <nom-role> -n <nom-namespace>
+
+# Décrire un ClusterRole
+kubectl describe clusterrole <nom-clusterrole>
+
+# Vérifier si une action est autorisée pour l'utilisateur courant
+kubectl auth can-i <verbe> <ressource> --namespace <nom-namespace>
+# Exemple: kubectl auth can-i list pods -n default
+
+# Vérifier pour un utilisateur spécifique
+kubectl auth can-i <verbe> <ressource> --as <nom-utilisateur> --namespace <nom-namespace>
+# Exemple: kubectl auth can-i create deployments --as jane.doe@example.com -n web-dev
+
+# Vérifier pour un ServiceAccount
+kubectl auth can-i <verbe> <ressource> --as system:serviceaccount:<nom-namespace>:<nom-sa> --namespace <nom-namespace>
+# Exemple: kubectl auth can-i get secrets --as system:serviceaccount:kube-system:replicaset-controller -n kube-system
+
+# (Si le plugin kubectl-whoami est installé) Voir l'identité actuelle utilisée par kubectl
+# kubectl whoami
+# Sinon, pour voir le nom de l'utilisateur dans le contexte actuel:
+kubectl config view -o jsonpath='{.contexts[?(@.name=="'$(kubectl config current-context)'")].context.user}'
+```
+
+---
+## Utilitaires Généraux `kubectl`
+
+### Changer le contexte actuel (si plusieurs clusters configurés)
+```bash
+# Lister les contextes disponibles
+kubectl config get-contexts
+# Afficher le contexte actuel
+kubectl config current-context
+# Changer de contexte
+kubectl config use-context <nom-du-contexte>
+```
+
+### Appliquer une configuration YAML
+```bash
+kubectl apply -f <nom-fichier.yaml_ou_url>
+# Pour appliquer tous les fichiers YAML dans un répertoire:
+kubectl apply -f <nom-repertoire>/
+```
+
+### Supprimer des ressources à partir d'un fichier YAML
+```bash
+kubectl delete -f <nom-fichier.yaml>
+```
+
+### Éditer une ressource en direct
+Ouvre l'éditeur par défaut (défini par $KUBE_EDITOR ou $EDITOR) pour modifier une ressource.
+```bash
+kubectl edit <type-ressource>/<nom-ressource> -n <nom-namespace>
+# Exemple: kubectl edit deployment/my-deployment -n default
+```
+
+### Obtenir la version du client et du serveur
+```bash
+kubectl version
+```
+
+### Obtenir la configuration de l'API pour une ressource
+Explique les champs d'une ressource.
+```bash
+kubectl explain <type-ressource>
+# Exemple: kubectl explain pod
+# Pour des champs spécifiques:
+kubectl explain pod.spec.containers
+```
+
+---
+*Fin de l'aide-mémoire.*


### PR DESCRIPTION
This commit delivers the full expansion of the Kubernetes tutorial, incorporating comprehensive documentation for Storage and Security, updating the cheat sheet, and restructuring the main README for better navigation.

Key additions since the last commit in this series:

Storage in Kubernetes:
- New overview page for storage concepts.
- Detailed pages for PersistentVolumes (PVs), PersistentVolumeClaims (PVCs), and StorageClasses, with examples and explanations of their interaction.

Security in Kubernetes:
- New overview page for Kubernetes security concepts (4 Cs, least privilege).
- Detailed page for Role-Based Access Control (RBAC) with examples of Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings.
- Detailed page for Security Contexts (Pod and Container level), covering key fields and best practices for securing workloads.

Cheat Sheet (`useful.md`):
- Significantly updated with kubectl commands for all newly added topics, including StatefulSets, DaemonSets, Jobs, CronJobs, ConfigMaps, Secrets, Ingress, NetworkPolicies, PVs, PVCs, StorageClasses, and RBAC objects.

README and Structure:
- The main `README.md` now features a comprehensive Table of Contents, providing easy navigation to all sections of the tutorial.
- "Next:" links in introductory and newly added files have been verified and updated to ensure a coherent learning path.

This completes the planned enhancements to the Formation-kubernetes project, making it a more extensive resource for learning Kubernetes.